### PR TITLE
Removal of the submissions data from study view

### DIFF
--- a/cmd/study/create.go
+++ b/cmd/study/create.go
@@ -93,7 +93,7 @@ func createStudy(client client.API, opts CreateOptions, w io.Writer) error {
 	}
 
 	if !opts.Silent {
-		fmt.Fprintln(w, studyui.RenderStudy(client, *study))
+		fmt.Fprintln(w, studyui.RenderStudy(*study))
 	}
 
 	return nil

--- a/cmd/study/view.go
+++ b/cmd/study/view.go
@@ -22,7 +22,7 @@ func NewViewCommand(client client.API, w io.Writer) *cobra.Command {
 				return fmt.Errorf("error: %s", err.Error())
 			}
 
-			fmt.Fprintln(w, studyui.RenderStudy(client, *study))
+			fmt.Fprintln(w, studyui.RenderStudy(*study))
 
 			return nil
 		},

--- a/cmd/study/view_test.go
+++ b/cmd/study/view_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/acarl005/stripansi"
 	"github.com/golang/mock/gomock"
-	"github.com/prolific-oss/prolificli/client"
 	"github.com/prolific-oss/prolificli/cmd/study"
 	"github.com/prolific-oss/prolificli/mock_client"
 	"github.com/prolific-oss/prolificli/model"
@@ -54,18 +53,10 @@ func TestViewStudyRendersStudy(t *testing.T) {
 		DeviceCompatibility:     []string{"desktop", "tablet", "mobile"},
 	}
 
-	ls := client.ListSubmissionsResponse{}
-
 	c.
 		EXPECT().
 		GetStudy(gomock.Eq(studyID)).
 		Return(&actualStudy, nil).
-		AnyTimes()
-
-	c.
-		EXPECT().
-		GetSubmissions(gomock.Eq(studyID), gomock.Eq(client.DefaultRecordLimit), gomock.Eq(client.DefaultRecordOffset)).
-		Return(&ls, nil).
 		AnyTimes()
 
 	var b bytes.Buffer
@@ -99,11 +90,6 @@ Eligibility requirements
 
 No eligibility requirements are defined for this study.
 
----
-
-Submissions
-
-No submissions have been submitted for this study yet.
 ---
 
 View study in the application: https://app.prolific.co/researcher/studies/11223344

--- a/ui/study/view.go
+++ b/ui/study/view.go
@@ -55,13 +55,13 @@ func (lv ListView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View will render the view.
 func (lv ListView) View() string {
 	if lv.Study != nil {
-		return docStyle.Render(RenderStudy(lv.Client, *lv.Study))
+		return docStyle.Render(RenderStudy(*lv.Study))
 	}
 	return docStyle.Render(lv.List.View())
 }
 
 // RenderStudy will produce a detailed view of the selected study.
-func RenderStudy(c client.API, study model.Study) string {
+func RenderStudy(study model.Study) string {
 	marker := "\n---\n\n"
 
 	content := fmt.Sprintln(ui.RenderTitle(study.Name, study.Status))
@@ -94,29 +94,6 @@ func RenderStudy(c client.API, study model.Study) string {
 		content += fmt.Sprintln("No eligibility requirements are defined for this study.")
 	} else {
 		content += erContent
-	}
-	content += marker
-
-	content += fmt.Sprintln(ui.RenderHeading("Submissions"))
-	submissions, err := c.GetSubmissions(study.ID, client.DefaultRecordLimit, client.DefaultRecordOffset)
-	if err != nil {
-		content += "Unable to retrieve submission data."
-	}
-
-	if len(submissions.Results) == 0 {
-		content += "No submissions have been submitted for this study yet."
-	} else {
-		content += fmt.Sprintf("%s\n", lipgloss.NewStyle().
-			Underline(true).
-			Render("This shows the first 200 responses\n\n"))
-
-		content += "Participant Prolific ID\tStarted\t\t\tCompletion code\tStatus\n"
-		content += "-----------------------\t-------\t\t\t---------------\t------\n"
-		for _, submission := range submissions.Results {
-			content += fmt.Sprintf("%s\t%s\t%s\t%s\n", submission.ParticipantID, submission.StartedAt.Format(ui.AppDateTimeFormat), submission.StudyCode, submission.Status)
-		}
-
-		content += fmt.Sprintf("\nFurther data can be found in the application: https://app.prolific.co/researcher/workspaces/studies/%s/submissions", study.ID)
 	}
 
 	content += marker


### PR DESCRIPTION
This is because you cannot easily control paging in this view. If you
want the submission data, you can get that from `submission list`.

This seems to steamline the flow somewhat. We don't need to pass around
the client within UI code, which is a win for me.
