### PR TITLE
Provide mode context on the `message list` params.

### DIFF
--- a/cmd/message/list.go
+++ b/cmd/message/list.go
@@ -39,8 +39,8 @@ func NewListCommand(commandName string, client client.API, w io.Writer) *cobra.C
 
 	flags := cmd.Flags()
 
-	flags.StringVarP(&opts.UserID, "user", "u", "", "Filter messages by user.")
-	flags.StringVarP(&opts.CreatedAfter, "created_after", "c", "", "Filter messages created after a certain date (YYYY-MM-DD).")
+	flags.StringVarP(&opts.UserID, "user", "u", "", "Filter messages sent to user.")
+	flags.StringVarP(&opts.CreatedAfter, "created_after", "c", "", "Filter messages created after a certain date (YYYY-MM-DD). You can only fetch up to the last 30 days of messages.")
 	flags.BoolVarP(&opts.Unread, "unread", "U", false, "Filter messages to show only unread. Cannot be used with any other flags.")
 
 	return cmd


### PR DESCRIPTION
This is pulled from the Open API docs, and I think is a little more
insightful.
