### PR TITLE
Consolidate where the application URL is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+- Provide an easy access link to the message centre in the `message list` command.
+
 ## 0.0.27
 
 - Provide `message list` command that allows you to pull back messages from the Prolific Platform.

--- a/cmd/hook/list_test.go
+++ b/cmd/hook/list_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/prolific-oss/cli/client"
 	"github.com/prolific-oss/cli/cmd/hook"
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/mock_client"
 	"github.com/prolific-oss/cli/model"
 )
@@ -92,7 +93,7 @@ func TestNewListCommandCallsTheAPI(t *testing.T) {
 			{
 				ID:          "hook-id",
 				EventType:   "wibble",
-				TargetURL:   "https://app.prolific.co",
+				TargetURL:   config.GetApplicationURL(),
 				IsEnabled:   true,
 				WorkspaceID: "workspace-id",
 			},
@@ -125,11 +126,11 @@ func TestNewListCommandCallsTheAPI(t *testing.T) {
 	writer.Flush()
 
 	actual := b.String()
-	expected := `ID      Event  Target URL              Enabled Workspace ID
-hook-id wibble https://app.prolific.co true    workspace-id
+	expected := fmt.Sprintf(`ID      Event  Target URL              Enabled Workspace ID
+hook-id wibble %s true    workspace-id
 
 Showing 1 record of 10
-`
+`, config.GetApplicationURL())
 
 	if actual != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)

--- a/cmd/message/list.go
+++ b/cmd/message/list.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/ui"
 	"github.com/spf13/cobra"
 )
@@ -96,5 +97,9 @@ func renderMessages(c client.API, opts ListOptions, w io.Writer) error {
 		}
 	}
 
-	return tw.Flush()
+	_ = tw.Flush()
+
+	fmt.Fprintf(w, "\nView messages in the application: %s/messages/inbox\n", config.GetApplicationURL())
+
+	return nil
 }

--- a/cmd/message/list_test.go
+++ b/cmd/message/list_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/prolific-oss/cli/client"
 	"github.com/prolific-oss/cli/cmd/message"
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/mock_client"
 	"github.com/prolific-oss/cli/model"
 )
@@ -100,9 +101,11 @@ func TestNewListCommandCallsTheAPI(t *testing.T) {
 	writer.Flush()
 
 	actual := b.String()
-	expected := `Sender ID Study ID Datetime Created Body
+	expected := fmt.Sprintf(`Sender ID Study ID Datetime Created Body
 sender-id study-id 27-01-2023 19:39 body
-`
+
+View messages in the application: %s/messages/inbox
+`, config.GetApplicationURL())
 
 	if actual != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
@@ -151,9 +154,11 @@ func TestNewListCommandWithUnreadFlagCallsTheAPI(t *testing.T) {
 	writer.Flush()
 
 	actual := b.String()
-	expected := `Sender ID Datetime Created Body
+	expected := fmt.Sprintf(`Sender ID Datetime Created Body
 sender-id 27-01-2023 19:39 body
-`
+
+View messages in the application: %s/messages/inbox
+`, config.GetApplicationURL())
 
 	if actual != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)

--- a/cmd/study/increase_places_test.go
+++ b/cmd/study/increase_places_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/acarl005/stripansi"
 	"github.com/golang/mock/gomock"
 	"github.com/prolific-oss/cli/cmd/study"
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/mock_client"
 	"github.com/prolific-oss/cli/model"
 )
@@ -176,7 +178,7 @@ func TestNewIncreasePlacesCommandRendersStudyOnceUpdated(t *testing.T) {
 		Name:                    "My first standard sample",
 		InternalName:            "Standard sample",
 		Desc:                    "This is my first standard sample study on the Prolific system.",
-		ExternalStudyURL:        "https://eggs-experriment.com?participant={{%PROLIFIC_PID%}}",
+		ExternalStudyURL:        "https://eggs-experriment.com?participant=",
 		TotalAvailablePlaces:    11,
 		EstimatedCompletionTime: 10,
 		MaximumAllowedTime:      10,
@@ -204,7 +206,7 @@ func TestNewIncreasePlacesCommandRendersStudyOnceUpdated(t *testing.T) {
 	_ = cmd.RunE(cmd, []string{studyID})
 	writer.Flush()
 
-	expected := `My first standard sample
+	expected := fmt.Sprintf(`My first standard sample
 This is my first standard sample study on the Prolific system.
 
 ID:                        11223344
@@ -215,7 +217,7 @@ Reward:                    £4.00
 Hourly rate:               £0.00
 Estimated completion time: 10
 Maximum allowed time:      10
-Study URL:                 https://eggs-experriment.com?participant={{%PROLIFIC_PID%}}
+Study URL:                 https://eggs-experriment.com?participant=
 Places taken:              0
 Available places:          11
 
@@ -226,8 +228,8 @@ No eligibility requirements are defined for this study.
 
 ---
 
-View study in the application: https://app.prolific.co/researcher/studies/11223344
-`
+View study in the application: %s/researcher/studies/11223344
+`, config.GetApplicationURL())
 
 	actual := stripansi.Strip(b.String())
 	actual = strings.ReplaceAll(actual, " ", "")

--- a/cmd/study/view_test.go
+++ b/cmd/study/view_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/acarl005/stripansi"
 	"github.com/golang/mock/gomock"
 	"github.com/prolific-oss/cli/cmd/study"
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/mock_client"
 	"github.com/prolific-oss/cli/model"
 )
@@ -46,7 +48,7 @@ func TestViewStudyRendersStudy(t *testing.T) {
 		Name:                    "My first standard sample",
 		InternalName:            "Standard sample",
 		Desc:                    "This is my first standard sample study on the Prolific system.",
-		ExternalStudyURL:        "https://eggs-experriment.com?participant={{%PROLIFIC_PID%}}",
+		ExternalStudyURL:        "https://eggs-experriment.com?participant=",
 		TotalAvailablePlaces:    10,
 		EstimatedCompletionTime: 10,
 		MaximumAllowedTime:      10,
@@ -67,7 +69,7 @@ func TestViewStudyRendersStudy(t *testing.T) {
 	_ = cmd.RunE(cmd, []string{studyID})
 	writer.Flush()
 
-	expected := `My first standard sample
+	expected := fmt.Sprintf(`My first standard sample
 This is my first standard sample study on the Prolific system.
 
 ID:                        11223344
@@ -78,7 +80,7 @@ Reward:                    £4.00
 Hourly rate:               £0.00
 Estimated completion time: 10
 Maximum allowed time:      10
-Study URL:                 https://eggs-experriment.com?participant={{%PROLIFIC_PID%}}
+Study URL:                 https://eggs-experriment.com?participant=
 Places taken:              0
 Available places:          10
 
@@ -89,8 +91,8 @@ No eligibility requirements are defined for this study.
 
 ---
 
-View study in the application: https://app.prolific.co/researcher/studies/11223344
-`
+View study in the application: %s/researcher/studies/11223344
+`, config.GetApplicationURL())
 
 	actual := stripansi.Strip(b.String())
 	actual = strings.ReplaceAll(actual, " ", "")

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,7 @@
+package config
+
+// GetApplicationURL will return the Application URL. This could be updated
+// to understand different environments based on API URL perhaps?
+func GetApplicationURL() string {
+	return "https://app.prolific.co"
+}

--- a/ui/study/view.go
+++ b/ui/study/view.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/model"
 	"github.com/prolific-oss/cli/ui"
 )
@@ -94,7 +95,7 @@ func RenderStudy(study model.Study) string {
 
 	content += fmt.Sprintf("\n%s\n\n", ui.RenderSectionMarker())
 
-	content += fmt.Sprintf("View study in the application: https://app.prolific.co/researcher/studies/%s", study.ID)
+	content += fmt.Sprintf("View study in the application: %s/researcher/studies/%s", config.GetApplicationURL(), study.ID)
 
 	return content
 }


### PR DESCRIPTION
A function may be overkill, but we could actually make this work for
other environments this way. For example we could look at the API token
adn return a local host URL when working locally. 🙈🤷‍♂️
