### PR TITLE
Turn the depguard linter off

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
 linters:
   disable-all: true
   enable:
-    - depguard
+    # - depguard
     - dogsled
     - dupl
     - errcheck


### PR DESCRIPTION
This seemingly published something that broke all the builds, even when
we hadn't updated a version. So for now, let's turn this off.
