### PR TITLE
Define dependabot groups for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,19 +23,8 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'gomod'
-
-  # Maintain dependencies for php
-  - package-ecosystem: 'composer'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: 'php'
-
-  # Maintain dependencies for npm
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: 'npm'
+    groups:
+      development-dependencies:
+        dependency-type: 'development'
+      production-dependencies:
+        dependency-type: 'production'


### PR DESCRIPTION
Go doesn't have a development dependency understanding, but will define
anyway
