### PR TITLE
Pull out the API url into it's own config function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/prolific-oss/cli/config"
 	"github.com/prolific-oss/cli/model"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
@@ -66,7 +67,7 @@ type Client struct {
 
 // New will return a new Prolific client.
 func New() Client {
-	viper.SetDefault("PROLIFIC_URL", "https://api.prolific.com")
+	viper.SetDefault("PROLIFIC_URL", config.GetAPIURL())
 
 	client := Client{
 		Client:  http.DefaultClient,

--- a/config/config.go
+++ b/config/config.go
@@ -5,3 +5,9 @@ package config
 func GetApplicationURL() string {
 	return "https://app.prolific.com"
 }
+
+// GetAPIURL will return the API URL. This is the default API, but we allow
+// users to override this with an environment variable.
+func GetAPIURL() string {
+	return "https://api.prolific.com"
+}


### PR DESCRIPTION
This makes it consistent with the GetApplicationURL function we have.
