### PR TITLE
Rename the `next` to `Unreleased` in the Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## next
+## Unreleased
 
 ## 0.0.38
 


### PR DESCRIPTION
Moving towards something like this: https://keepachangelog.com/en/1.1.0/
