### PR TITLE
Provide a project detail view command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
-## Unreleased
+## 0.0.41
+
+- Provide a project detail view `project view [id]`.
 
 ## 0.0.38
 

--- a/client/client.go
+++ b/client/client.go
@@ -46,6 +46,7 @@ type API interface {
 
 	GetProjects(workspaceID string, limit, offset int) (*ListProjectsResponse, error)
 	CreateProject(workspaceID string, project model.Project) (*CreateProjectResponse, error)
+	GetProject(ID string) (*model.Project, error)
 
 	GetParticipantGroups(projectID string, limit, offset int) (*ListParticipantGroupsResponse, error)
 	GetParticipantGroup(groupID string) (*ViewParticipantGroupResponse, error)
@@ -384,6 +385,19 @@ func (c *Client) GetProjects(workspaceID string, limit, offset int) (*ListProjec
 	var response ListProjectsResponse
 
 	url := fmt.Sprintf("/api/v1/workspaces/%s/projects/?limit=%v&offset=%v", workspaceID, limit, offset)
+	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	return &response, nil
+}
+
+// GetProject will return the project for the given project ID
+func (c *Client) GetProject(ID string) (*model.Project, error) {
+	var response model.Project
+
+	url := fmt.Sprintf("/api/v1/projects/%s/", ID)
 	_, err := c.Execute(http.MethodGet, url, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -20,6 +20,7 @@ Projects are a way to organise studies in a workspace.
 	cmd.AddCommand(
 		NewListCommand("list", client, w),
 		NewCreateCommand("create", client, w),
+		NewViewCommand("view", client, w),
 	)
 	return cmd
 }

--- a/cmd/project/view.go
+++ b/cmd/project/view.go
@@ -1,0 +1,82 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/ui"
+	"github.com/spf13/cobra"
+)
+
+// ViewOptions is the options for the detail view of a project.
+type ViewOptions struct {
+	Args []string
+}
+
+// NewViewCommand creates a new command to show a project.
+func NewViewCommand(commandName string, client client.API, w io.Writer) *cobra.Command {
+	var opts ListOptions
+
+	cmd := &cobra.Command{
+		Use:   commandName,
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Provide details about your project",
+		Long: `View your project
+
+A detailed view of how your project is configured.
+`,
+		Example: `
+View the details of a specific project
+
+$ prolific project view 6261321e223a605c7a4f7678
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := renderProject(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// renderProject will show your project
+func renderProject(client client.API, opts ListOptions, w io.Writer) error {
+	if len(opts.Args) < 1 || opts.Args[0] == "" {
+		return errors.New("please provide a project ID")
+	}
+
+	project, err := client.GetProject(opts.Args[0])
+	if err != nil {
+		return err
+	}
+
+	content := fmt.Sprintln(ui.RenderHeading(project.Title))
+
+	if project.Description != "" {
+		content += fmt.Sprintf("%s\n", project.Description)
+	}
+
+	content += fmt.Sprintf("\nOwner:                     %v", project.Owner)
+	content += fmt.Sprintf("\nNaivety distribution rate: %v", project.NaivetyDistributionRate)
+	content += "\n"
+
+	content += "\nUsers:"
+
+	tw := tabwriter.NewWriter(w, 0, 1, 1, ' ', 0)
+	fmt.Fprintf(tw, "%s\t%s\t%s\n", "ID", "Name", "Email")
+	for _, user := range project.Users {
+		fmt.Fprintf(tw, "%s\t%s\t%v\n", user.ID, user.Name, user.Email)
+	}
+
+	fmt.Fprintln(w, content)
+	return tw.Flush()
+}

--- a/cmd/project/view_test.go
+++ b/cmd/project/view_test.go
@@ -1,0 +1,126 @@
+package project_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/cmd/project"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewViewCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := project.NewViewCommand("view", c, os.Stdout)
+
+	use := "view"
+	short := "Provide details about your project"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected use: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewViewCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	projectID := "991199"
+	response := model.Project{
+		ID:                      projectID,
+		Title:                   "Titan",
+		Description:             "Project about moons",
+		Owner:                   "Dr. Who",
+		NaivetyDistributionRate: 0.6,
+		Users: []model.User{
+			{
+				ID:    "123",
+				Name:  "Dr Who",
+				Email: "dr@who.me",
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		GetProject(gomock.Eq(projectID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := project.NewViewCommand("view", c, writer)
+	_ = cmd.RunE(cmd, []string{projectID})
+
+	writer.Flush()
+
+	expected := `Titan
+Project about moons
+
+Owner:                     Dr. Who
+Naivety distribution rate: 0.6
+
+Users:
+ID  Name   Email
+123 Dr Who dr@who.me
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, b.String())
+	}
+}
+
+func TestNewViewCommandHandlesErrorsFromTheCliParams(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	errorMessage := "please provide a project ID"
+
+	cmd := project.NewViewCommand("view", c, os.Stdout)
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestNewViewCommandHandlesErrorsFromTheAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	projectID := "project-id"
+	errorMessage := "API says no"
+
+	c.
+		EXPECT().
+		GetProject(gomock.Eq(projectID)).
+		Return(nil, errors.New(errorMessage)).
+		AnyTimes()
+
+	cmd := project.NewViewCommand("view", c, os.Stdout)
+	err := cmd.RunE(cmd, []string{projectID})
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -245,6 +245,21 @@ func (mr *MockAPIMockRecorder) GetParticipantGroups(projectID, limit, offset int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParticipantGroups", reflect.TypeOf((*MockAPI)(nil).GetParticipantGroups), projectID, limit, offset)
 }
 
+// GetProject mocks base method.
+func (m *MockAPI) GetProject(ID string) (*model.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProject", ID)
+	ret0, _ := ret[0].(*model.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProject indicates an expected call of GetProject.
+func (mr *MockAPIMockRecorder) GetProject(ID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockAPI)(nil).GetProject), ID)
+}
+
 // GetProjects mocks base method.
 func (m *MockAPI) GetProjects(workspaceID string, limit, offset int) (*client.ListProjectsResponse, error) {
 	m.ctrl.T.Helper()

--- a/model/model.go
+++ b/model/model.go
@@ -43,6 +43,7 @@ type Project struct {
 	ID                      string  `json:"id"`
 	Title                   string  `json:"title"`
 	Description             string  `json:"description"`
+	Owner                   string  `json:"owner"`
 	Users                   []User  `json:"users"`
 	NaivetyDistributionRate float64 `json:"naivety_distribution_rate"`
 }


### PR DESCRIPTION
This could also be applied to the workspace namespace. We have extra settings now available on both workspace and projects.

For now this will show:

- Title
- Description
- Owner (ID only)
- Naivety distribution rate
- Users part of the project