### PR TITLE
feat(#203): :sparkles: add get batch status by batch id command Closes #203

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,7 @@ type API interface {
 	GetUnreadMessages() (*ListUnreadMessagesResponse, error)
 
 	GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchResponse, error)
+	GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error)
 }
 
 // Client is responsible for interacting with the Prolific API.
@@ -601,5 +602,17 @@ func (c *Client) GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchRe
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}
 
+	return &response, nil
+}
+
+// GetAITaskBuilderBatchStatus will return the status of an AI task builder batch.
+func (c *Client) GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error) {
+	var response GetAITaskBuilderBatchStatusResponse
+
+	url := fmt.Sprintf("/api/v1/data-collection/batches/%s/status", batchID)
+	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
 	return &response, nil
 }

--- a/client/responses.go
+++ b/client/responses.go
@@ -191,3 +191,8 @@ type ListUnreadMessagesResponse struct {
 type GetAITaskBuilderBatchResponse struct {
 	model.AITaskBuilderBatch
 }
+
+// GetAITaskBuilderBatchStatusResponse is the response for the get AI task builder get batch status endpoint.
+type GetAITaskBuilderBatchStatusResponse struct {
+	model.AITaskBuilderBatchStatus
+}

--- a/cmd/aitaskbuilder/aitaskbuilder.go
+++ b/cmd/aitaskbuilder/aitaskbuilder.go
@@ -16,7 +16,8 @@ func NewAITaskBuilderCommand(client client.API, w io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		NewGetCommand(client, w),
+		GetBatchCommand(client, w),
+		GetBatchStatusCommand(client, w),
 	)
 
 	return cmd

--- a/cmd/aitaskbuilder/get_batch.go
+++ b/cmd/aitaskbuilder/get_batch.go
@@ -9,19 +9,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// BatchGetOptions is the options for the get aitaskbuilder batch command.
 type BatchGetOptions struct {
 	Args    []string
 	BatchID string
 }
 
-// NewGetCommand creates a new `aitaskbuilder get` command to get details about
-// a specific AI task builder batch.
-func NewGetCommand(client client.API, w io.Writer) *cobra.Command {
+func GetBatchCommand(client client.API, w io.Writer) *cobra.Command {
 	var opts BatchGetOptions
 
 	cmd := &cobra.Command{
-		Use:   "get",
+		Use:   "getbatch",
 		Short: "Get an AI task builder batch",
 		Long: `Get details about a specific AI task builder batch
 

--- a/cmd/aitaskbuilder/get_batch_status.go
+++ b/cmd/aitaskbuilder/get_batch_status.go
@@ -1,0 +1,66 @@
+package aitaskbuilder
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+type BatchGetStatusOptions struct {
+	Args    []string
+	BatchID string
+}
+
+func GetBatchStatusCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts BatchGetStatusOptions
+
+	cmd := &cobra.Command{
+		Use:   "getbatchstatus",
+		Short: "Get an AI task builder batch status",
+		Long: `Get the status of a specific AI task builder batch
+
+This command allows you to retrieve the status of a specific AI task builder batch by providing
+the batch ID.`,
+		Example: `
+Get an AI task builder batch status:
+$ prolific aitaskbuilder get-batch-status -b <batch_id>
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := renderAITaskBuilderBatchStatus(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.BatchID, "batch-id", "b", "", "Batch ID (required) - The ID of the batch to retrieve.")
+
+	_ = cmd.MarkFlagRequired("batch-id")
+
+	return cmd
+}
+
+func renderAITaskBuilderBatchStatus(c client.API, opts BatchGetStatusOptions, w io.Writer) error {
+	if opts.BatchID == "" {
+		return errors.New("batch ID is required")
+	}
+
+	response, err := c.GetAITaskBuilderBatchStatus(opts.BatchID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "AI Task Builder Batch Status:\n")
+	fmt.Fprintf(w, "Batch ID: %s\n", opts.BatchID)
+	fmt.Fprintf(w, "Status: %s\n", response.Status)
+
+	return nil
+}

--- a/cmd/aitaskbuilder/get_batch_status_test.go
+++ b/cmd/aitaskbuilder/get_batch_status_test.go
@@ -1,0 +1,118 @@
+package aitaskbuilder_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/aitaskbuilder"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewGetBatchStatusCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.GetBatchStatusCommand(c, os.Stdout)
+
+	use := "getbatchstatus"
+	short := "Get an AI task builder batch status"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewGetBatchStatusCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "01954894-65b3-779e-aaf6-348698e23612"
+
+	response := client.GetAITaskBuilderBatchStatusResponse{
+		AITaskBuilderBatchStatus: model.AITaskBuilderBatchStatus{
+			Status: "UNINITIALISED",
+		},
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderBatchStatus(gomock.Eq(batchID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.GetBatchStatusCommand(c, writer)
+	_ = cmd.Flags().Set("batch-id", batchID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Batch Status:
+Batch ID: 01954894-65b3-779e-aaf6-348698e23612
+Status: UNINITIALISED
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetBatchStatusCommandHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "invalid-batch-id"
+	errorMessage := "batch not found"
+
+	c.
+		EXPECT().
+		GetAITaskBuilderBatchStatus(gomock.Eq(batchID)).
+		Return(nil, errors.New(errorMessage)).
+		AnyTimes()
+
+	cmd := aitaskbuilder.GetBatchStatusCommand(c, os.Stdout)
+	_ = cmd.Flags().Set("batch-id", batchID)
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestNewGetBatchStatusCommandRequiresBatchID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.GetBatchStatusCommand(c, os.Stdout)
+	err := cmd.RunE(cmd, nil)
+
+	if err == nil {
+		t.Fatal("expected error when batch-id is missing")
+	}
+
+	if !cmd.Flags().Changed("batch-id") {
+		expected := "batch ID is required"
+		if err.Error() != "error: "+expected {
+			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
+		}
+	}
+}

--- a/cmd/aitaskbuilder/get_batch_test.go
+++ b/cmd/aitaskbuilder/get_batch_test.go
@@ -16,14 +16,14 @@ import (
 	"github.com/prolific-oss/cli/model"
 )
 
-func TestNewGetCommand(t *testing.T) {
+func TestNewGetBatchCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	cmd := aitaskbuilder.NewGetCommand(c, os.Stdout)
+	cmd := aitaskbuilder.GetBatchCommand(c, os.Stdout)
 
-	use := "get"
+	use := "getbatch"
 	short := "Get an AI task builder batch"
 
 	if cmd.Use != use {
@@ -35,12 +35,12 @@ func TestNewGetCommand(t *testing.T) {
 	}
 }
 
-func TestNewGetCommandCallsAPI(t *testing.T) {
+func TestNewGetBatchCommandCallsAPI(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := "01954894-65b3-779e-aaf6-348698e23608"
+	batchID := "01954894-65b3-779e-aaf6-348698e23634"
 
 	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
 	response := client.GetAITaskBuilderBatchResponse{
@@ -77,14 +77,14 @@ func TestNewGetCommandCallsAPI(t *testing.T) {
 	var b bytes.Buffer
 	writer := bufio.NewWriter(&b)
 
-	cmd := aitaskbuilder.NewGetCommand(c, writer)
+	cmd := aitaskbuilder.GetBatchCommand(c, writer)
 	_ = cmd.Flags().Set("batch-id", batchID)
 	_ = cmd.RunE(cmd, nil)
 
 	writer.Flush()
 
 	expected := `AI Task Builder Batch Details:
-ID: 01954894-65b3-779e-aaf6-348698e23608
+ID: 01954894-65b3-779e-aaf6-348698e23634
 Name: Test Batch
 Status: UNINITIALISED
 Total Task Count: 0
@@ -107,12 +107,12 @@ Task Details:
 	}
 }
 
-func TestNewGetCommandCallsAPIWithoutOptionalFields(t *testing.T) {
+func TestNewGetBatchCommandCallsAPIWithoutOptionalFields(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := "01954894-65b3-779e-aaf6-348698e23608"
+	batchID := "01954894-65b3-779e-aaf6-348698e23699"
 
 	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
 	response := client.GetAITaskBuilderBatchResponse{
@@ -140,14 +140,14 @@ func TestNewGetCommandCallsAPIWithoutOptionalFields(t *testing.T) {
 	var b bytes.Buffer
 	writer := bufio.NewWriter(&b)
 
-	cmd := aitaskbuilder.NewGetCommand(c, writer)
+	cmd := aitaskbuilder.GetBatchCommand(c, writer)
 	_ = cmd.Flags().Set("batch-id", batchID)
 	_ = cmd.RunE(cmd, nil)
 
 	writer.Flush()
 
 	expected := `AI Task Builder Batch Details:
-ID: 01954894-65b3-779e-aaf6-348698e23608
+ID: 01954894-65b3-779e-aaf6-348698e23699
 Name: Simple Batch
 Status: ACTIVE
 Total Task Count: 5
@@ -163,7 +163,7 @@ Schema Version: 1
 	}
 }
 
-func TestNewGetCommandHandlesErrors(t *testing.T) {
+func TestNewGetBatchCommandHandlesErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
@@ -177,7 +177,7 @@ func TestNewGetCommandHandlesErrors(t *testing.T) {
 		Return(nil, errors.New(errorMessage)).
 		AnyTimes()
 
-	cmd := aitaskbuilder.NewGetCommand(c, os.Stdout)
+	cmd := aitaskbuilder.GetBatchCommand(c, os.Stdout)
 	_ = cmd.Flags().Set("batch-id", batchID)
 	err := cmd.RunE(cmd, nil)
 
@@ -188,12 +188,12 @@ func TestNewGetCommandHandlesErrors(t *testing.T) {
 	}
 }
 
-func TestNewGetCommandRequiresBatchID(t *testing.T) {
+func TestNewGetBatchCommandRequiresBatchID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	cmd := aitaskbuilder.NewGetCommand(c, os.Stdout)
+	cmd := aitaskbuilder.GetBatchCommand(c, os.Stdout)
 	err := cmd.RunE(cmd, nil)
 
 	if err == nil {

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -110,6 +110,21 @@ func (mr *MockAPIMockRecorder) GetAITaskBuilderBatch(batchID interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatch", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatch), batchID)
 }
 
+// GetAITaskBuilderBatchStatus mocks base method.
+func (m *MockAPI) GetAITaskBuilderBatchStatus(batchID string) (*client.GetAITaskBuilderBatchStatusResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAITaskBuilderBatchStatus", batchID)
+	ret0, _ := ret[0].(*client.GetAITaskBuilderBatchStatusResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAITaskBuilderBatchStatus indicates an expected call of GetAITaskBuilderBatchStatus.
+func (mr *MockAPIMockRecorder) GetAITaskBuilderBatchStatus(batchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatchStatus", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatchStatus), batchID)
+}
+
 // GetCampaigns mocks base method.
 func (m *MockAPI) GetCampaigns(workspaceID string, limit, offset int) (*client.ListCampaignsResponse, error) {
 	m.ctrl.T.Helper()

--- a/model/ai_task_builder.go
+++ b/model/ai_task_builder.go
@@ -19,6 +19,11 @@ type AITaskBuilderBatch struct {
 	TaskDetails           TaskDetails `json:"task_details"`
 }
 
+// AITaskBuilderBatchStatus represents the status of an AI task builder batch.
+type AITaskBuilderBatchStatus struct {
+	Status AITaskBuilderBatchStatusEnum `json:"status"`
+}
+
 // Dataset represents a dataset in a batch.
 type Dataset struct {
 	ID                  string `json:"id"`
@@ -31,3 +36,16 @@ type TaskDetails struct {
 	TaskIntroduction string `json:"task_introduction"`
 	TaskSteps        string `json:"task_steps"`
 }
+
+type AITaskBuilderBatchStatusEnum string
+
+const (
+	// UNINITIALISED: the batch has been created, but contains no tasks.
+	AITaskBuilderBatchStatusUninitialised AITaskBuilderBatchStatusEnum = "UNINITIALISED"
+	// PROCESSING: The batch is being processed into tasks.
+	AITaskBuilderBatchStatusProcessing AITaskBuilderBatchStatusEnum = "PROCESSING"
+	// READY: The batch is processed and ready to be attached to a Prolific study.
+	AITaskBuilderBatchStatusReady AITaskBuilderBatchStatusEnum = "READY"
+	// ERROR: The batch has encountered an error and the data may not be usable.
+	AITaskBuilderBatchStatusError AITaskBuilderBatchStatusEnum = "ERROR"
+)


### PR DESCRIPTION
adds clear get batch status command, incl minor naming refactor of get to getbatch to make usage clearer for users, incl unit tests based on mock client

`prolific aitaskbuilder getbatchstatus --batch-id 12354894-65b3-779e-aaf6-348698e23123
AI Task Builder Batch Status:
Batch ID: 12354894-65b3-779e-aaf6-348698e23123
Status: UNINITIALISED`