### PR TITLE
Closes #205 Add get aitb task responses command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -65,6 +65,7 @@ type API interface {
 	GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchResponse, error)
 	GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error)
 	GetAITaskBuilderBatches(workspaceID string) (*GetAITaskBuilderBatchesResponse, error)
+	GetAITaskBuilderResponses(batchID string) (*GetAITaskBuilderResponsesResponse, error)
 }
 
 // Client is responsible for interacting with the Prolific API.
@@ -593,7 +594,7 @@ func (c *Client) GetUnreadMessages() (*ListUnreadMessagesResponse, error) {
 	return &response, nil
 }
 
-// GetAITaskBuilderBatch will return details of an AI task builder batch.
+// GetAITaskBuilderBatch will return details of an AI Task Builder batch.
 func (c *Client) GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchResponse, error) {
 	var response GetAITaskBuilderBatchResponse
 
@@ -606,7 +607,7 @@ func (c *Client) GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchRe
 	return &response, nil
 }
 
-// GetAITaskBuilderBatchStatus will return the status of an AI task builder batch.
+// GetAITaskBuilderBatchStatus will return the status of an AI Task Builder batch.
 func (c *Client) GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error) {
 	var response GetAITaskBuilderBatchStatusResponse
 
@@ -623,6 +624,18 @@ func (c *Client) GetAITaskBuilderBatches(workspaceID string) (*GetAITaskBuilderB
 	var response GetAITaskBuilderBatchesResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/batches/?workspace_id=%s", workspaceID)
+	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+	return &response, nil
+}
+
+// GetAITaskBuilderResponses will return the responses for an AI Task Builder batch.
+func (c *Client) GetAITaskBuilderResponses(batchID string) (*GetAITaskBuilderResponsesResponse, error) {
+	var response GetAITaskBuilderResponsesResponse
+
+	url := fmt.Sprintf("/api/v1/data-collection/batches/%s/responses", batchID)
 	_, err := c.Execute(http.MethodGet, url, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)

--- a/client/responses.go
+++ b/client/responses.go
@@ -204,5 +204,11 @@ type GetAITaskBuilderBatchesResponse struct {
 
 // GetAITaskBuilderResponsesResponse is the response for the get AI Task Builder responses endpoint.
 type GetAITaskBuilderResponsesResponse struct {
-	Responses []model.AITaskBuilderResponse `json:"responses"`
+	Results []model.AITaskBuilderResponse `json:"results"`
+	Meta    ResponseMeta                  `json:"meta"`
+}
+
+// ResponseMeta contains metadata about the response.
+type ResponseMeta struct {
+	Count int `json:"count"`
 }

--- a/client/responses.go
+++ b/client/responses.go
@@ -201,3 +201,8 @@ type GetAITaskBuilderBatchStatusResponse struct {
 type GetAITaskBuilderBatchesResponse struct {
 	Results []model.AITaskBuilderBatch `json:"results"`
 }
+
+// GetAITaskBuilderResponsesResponse is the response for the get AI Task Builder responses endpoint.
+type GetAITaskBuilderResponsesResponse struct {
+	Responses []model.AITaskBuilderResponse `json:"responses"`
+}

--- a/cmd/aitaskbuilder/aitaskbuilder.go
+++ b/cmd/aitaskbuilder/aitaskbuilder.go
@@ -19,6 +19,7 @@ func NewAITaskBuilderCommand(client client.API, w io.Writer) *cobra.Command {
 		NewGetBatchCommand(client, w),
 		NewGetBatchStatusCommand(client, w),
 		NewGetBatchesCommand(client, w),
+		NewGetResponsesCommand(client, w),
 	)
 
 	return cmd

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -5,7 +5,4 @@ const (
 	// Error messages
 	ErrBatchIDRequired = "batch ID is required"
 	ErrBatchNotFound   = "batch not found"
-
-	// Test values
-	TestInvalidBatchID = "invalid-batch-id"
 )

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -1,0 +1,11 @@
+package aitaskbuilder
+
+// Test constants used across AI Task Builder commands and tests
+const (
+	// Error messages
+	ErrBatchIDRequired = "batch ID is required"
+	ErrBatchNotFound   = "batch not found"
+
+	// Test values
+	TestInvalidBatchID = "invalid-batch-id"
+)

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -1,6 +1,5 @@
 package aitaskbuilder
 
-// Test constants used across AI Task Builder commands and tests
 const (
 	// Error messages
 	ErrBatchIDRequired = "batch ID is required"

--- a/cmd/aitaskbuilder/get_batch.go
+++ b/cmd/aitaskbuilder/get_batch.go
@@ -19,13 +19,13 @@ func NewGetBatchCommand(client client.API, w io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "getbatch",
-		Short: "Get an AI task builder batch",
-		Long: `Get details about a specific AI task builder batch
+		Short: "Get an AI Task Builder batch",
+		Long: `Get details about a specific AI Task Builder batch
 
-This command allows you to retrieve details of a specific AI task builder batch by providing
+This command allows you to retrieve details of a specific AI Task Builder batch by providing
 the batch ID.`,
 		Example: `
-Get an AI task builder batch:
+Get an AI Task Builder batch:
 $ prolific aitaskbuilder get -b <batch_id>
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -48,10 +48,10 @@ $ prolific aitaskbuilder get -b <batch_id>
 	return cmd
 }
 
-// renderAITaskBuilderBatch will show details of a specific AI task builder batch
+// renderAITaskBuilderBatch will show details of a specific AI Task Builder batch
 func renderAITaskBuilderBatch(c client.API, opts BatchGetOptions, w io.Writer) error {
 	if opts.BatchID == "" {
-		return errors.New("batch ID is required")
+		return errors.New(ErrBatchIDRequired)
 	}
 
 	response, err := c.GetAITaskBuilderBatch(opts.BatchID)

--- a/cmd/aitaskbuilder/get_batch_status.go
+++ b/cmd/aitaskbuilder/get_batch_status.go
@@ -19,13 +19,13 @@ func NewGetBatchStatusCommand(client client.API, w io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "getbatchstatus",
-		Short: "Get an AI task builder batch status",
-		Long: `Get the status of a specific AI task builder batch
+		Short: "Get an AI Task Builder batch status",
+		Long: `Get the status of a specific AI Task Builder batch
 
-This command allows you to retrieve the status of a specific AI task builder batch by providing
+This command allows you to retrieve the status of a specific AI Task Builder batch by providing
 the batch ID.`,
 		Example: `
-Get an AI task builder batch status:
+Get an AI Task Builder batch status:
 $ prolific aitaskbuilder getbatchstatus -b <batch_id>
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,7 +50,7 @@ $ prolific aitaskbuilder getbatchstatus -b <batch_id>
 
 func renderAITaskBuilderBatchStatus(c client.API, opts BatchGetStatusOptions, w io.Writer) error {
 	if opts.BatchID == "" {
-		return errors.New("batch ID is required")
+		return errors.New(ErrBatchIDRequired)
 	}
 
 	response, err := c.GetAITaskBuilderBatchStatus(opts.BatchID)

--- a/cmd/aitaskbuilder/get_batch_status_test.go
+++ b/cmd/aitaskbuilder/get_batch_status_test.go
@@ -23,7 +23,7 @@ func TestNewGetBatchStatusCommand(t *testing.T) {
 	cmd := aitaskbuilder.NewGetBatchStatusCommand(c, os.Stdout)
 
 	use := "getbatchstatus"
-	short := "Get an AI task builder batch status"
+	short := "Get an AI Task Builder batch status"
 
 	if cmd.Use != use {
 		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
@@ -77,8 +77,8 @@ func TestNewGetBatchStatusCommandHandlesErrors(t *testing.T) {
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := "invalid-batch-id"
-	errorMessage := "batch not found"
+	batchID := aitaskbuilder.TestInvalidBatchID
+	errorMessage := aitaskbuilder.ErrBatchNotFound
 
 	c.
 		EXPECT().
@@ -110,7 +110,7 @@ func TestNewGetBatchStatusCommandRequiresBatchID(t *testing.T) {
 	}
 
 	if !cmd.Flags().Changed("batch-id") {
-		expected := "batch ID is required"
+		expected := aitaskbuilder.ErrBatchIDRequired
 		if err.Error() != "error: "+expected {
 			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
 		}

--- a/cmd/aitaskbuilder/get_batch_status_test.go
+++ b/cmd/aitaskbuilder/get_batch_status_test.go
@@ -77,7 +77,7 @@ func TestNewGetBatchStatusCommandHandlesErrors(t *testing.T) {
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := aitaskbuilder.TestInvalidBatchID
+	batchID := "the-invalid-batch-id"
 	errorMessage := aitaskbuilder.ErrBatchNotFound
 
 	c.

--- a/cmd/aitaskbuilder/get_batch_test.go
+++ b/cmd/aitaskbuilder/get_batch_test.go
@@ -24,7 +24,7 @@ func TestNewGetBatchCommand(t *testing.T) {
 	cmd := aitaskbuilder.NewGetBatchCommand(c, os.Stdout)
 
 	use := "getbatch"
-	short := "Get an AI task builder batch"
+	short := "Get an AI Task Builder batch"
 
 	if cmd.Use != use {
 		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
@@ -168,8 +168,8 @@ func TestNewGetBatchCommandHandlesErrors(t *testing.T) {
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := "invalid-batch-id"
-	errorMessage := "batch not found"
+	batchID := aitaskbuilder.TestInvalidBatchID
+	errorMessage := aitaskbuilder.ErrBatchNotFound
 
 	c.
 		EXPECT().
@@ -201,7 +201,7 @@ func TestNewGetBatchCommandRequiresBatchID(t *testing.T) {
 	}
 
 	if !cmd.Flags().Changed("batch-id") {
-		expected := "batch ID is required"
+		expected := aitaskbuilder.ErrBatchIDRequired
 		if err.Error() != "error: "+expected {
 			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
 		}

--- a/cmd/aitaskbuilder/get_batch_test.go
+++ b/cmd/aitaskbuilder/get_batch_test.go
@@ -168,7 +168,7 @@ func TestNewGetBatchCommandHandlesErrors(t *testing.T) {
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := aitaskbuilder.TestInvalidBatchID
+	batchID := "an-invalid-batch-id"
 	errorMessage := aitaskbuilder.ErrBatchNotFound
 
 	c.

--- a/cmd/aitaskbuilder/get_task_responses.go
+++ b/cmd/aitaskbuilder/get_task_responses.go
@@ -1,0 +1,88 @@
+package aitaskbuilder
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+type BatchGetResponsesOptions struct {
+	Args    []string
+	BatchID string
+}
+
+func NewGetResponsesCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts BatchGetResponsesOptions
+
+	cmd := &cobra.Command{
+		Use:   "getresponses",
+		Short: "Get AI Task Builder batch responses",
+		Long: `Get the responses for a specific AI Task Builder batch
+
+This command allows you to retrieve all responses for a specific AI Task Builder batch by providing
+the batch ID.`,
+		Example: `
+Get AI Task Builder batch responses:
+$ prolific aitaskbuilder getresponses -b <batch_id>
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := renderAITaskBuilderResponses(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.BatchID, "batch-id", "b", "", "Batch ID (required) - The ID of the batch to retrieve responses from.")
+
+	_ = cmd.MarkFlagRequired("batch-id")
+
+	return cmd
+}
+
+func renderAITaskBuilderResponses(c client.API, opts BatchGetResponsesOptions, w io.Writer) error {
+	if opts.BatchID == "" {
+		return errors.New(ErrBatchIDRequired)
+	}
+
+	response, err := c.GetAITaskBuilderResponses(opts.BatchID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "AI Task Builder Batch Responses:\n")
+	fmt.Fprintf(w, "Batch ID: %s\n", opts.BatchID)
+	fmt.Fprintf(w, "Total Responses: %d\n", len(response.Responses))
+	fmt.Fprintf(w, "\n")
+
+	if len(response.Responses) == 0 {
+		fmt.Fprintf(w, "No responses found for batch %s\n", opts.BatchID)
+		return nil
+	}
+
+	for i, resp := range response.Responses {
+		fmt.Fprintf(w, "Response %d:\n", i+1)
+		fmt.Fprintf(w, "  ID: %s\n", resp.ID)
+		fmt.Fprintf(w, "  Participant ID: %s\n", resp.ParticipantID)
+		fmt.Fprintf(w, "  Task ID: %s\n", resp.TaskID)
+		fmt.Fprintf(w, "  Created At: %s\n", resp.CreatedAt.Format("2006-01-02 15:04:05"))
+		fmt.Fprintf(w, "  Response:\n")
+		fmt.Fprintf(w, "    Instruction ID: %s\n", resp.Response.InstructionID)
+		fmt.Fprintf(w, "    Type: %s\n", resp.Response.Type)
+		fmt.Fprintf(w, "    Answer: %s\n", resp.Response.Answer)
+
+		if i < len(response.Responses)-1 {
+			fmt.Fprintf(w, "\n")
+		}
+	}
+
+	return nil
+}

--- a/cmd/aitaskbuilder/get_task_responses_test.go
+++ b/cmd/aitaskbuilder/get_task_responses_test.go
@@ -161,7 +161,7 @@ func TestNewGetResponsesCommandHandlesErrors(t *testing.T) {
 	defer ctrl.Finish()
 	c := mock_client.NewMockAPI(ctrl)
 
-	batchID := aitaskbuilder.TestInvalidBatchID
+	batchID := "such-invalid-batch-id"
 	errorMessage := aitaskbuilder.ErrBatchNotFound
 
 	c.

--- a/cmd/aitaskbuilder/get_task_responses_test.go
+++ b/cmd/aitaskbuilder/get_task_responses_test.go
@@ -1,0 +1,262 @@
+package aitaskbuilder_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/aitaskbuilder"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewGetResponsesCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewGetResponsesCommand(c, os.Stdout)
+
+	use := "getresponses"
+	short := "Get AI Task Builder batch responses"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewGetResponsesCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "5cf3ea63-3980-4149-9ea9-bea243489cc8"
+
+	createdAt := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	response := client.GetAITaskBuilderResponsesResponse{
+		Responses: []model.AITaskBuilderResponse{
+			{
+				ID:            "response-123",
+				CreatedAt:     createdAt,
+				BatchID:       batchID,
+				ParticipantID: "participant-456",
+				Response: model.AITaskBuilderResponseData{
+					InstructionID: "instruction-001",
+					Type:          "text",
+					Answer:        "test response",
+				},
+				TaskID: "task-456",
+			},
+			{
+				ID:            "response-789",
+				CreatedAt:     createdAt,
+				BatchID:       batchID,
+				ParticipantID: "participant-789",
+				Response: model.AITaskBuilderResponseData{
+					InstructionID: "instruction-002",
+					Type:          "multiple-choice",
+					Answer:        "another response",
+				},
+				TaskID: "task-101",
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderResponses(gomock.Eq(batchID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetResponsesCommand(c, writer)
+	_ = cmd.Flags().Set("batch-id", batchID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Batch Responses:
+Batch ID: 5cf3ea63-3980-4149-9ea9-bea243489cc8
+Total Responses: 2
+
+Response 1:
+  ID: response-123
+  Participant ID: participant-456
+  Task ID: task-456
+  Created At: 2024-01-01 12:00:00
+  Response:
+    Instruction ID: instruction-001
+    Type: text
+    Answer: test response
+
+Response 2:
+  ID: response-789
+  Participant ID: participant-789
+  Task ID: task-101
+  Created At: 2024-01-01 12:00:00
+  Response:
+    Instruction ID: instruction-002
+    Type: multiple-choice
+    Answer: another response
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetResponsesCommandHandlesEmptyResults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "5d883286-9480-463a-a738-9ddcfae65b8b"
+
+	response := client.GetAITaskBuilderResponsesResponse{
+		Responses: []model.AITaskBuilderResponse{},
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderResponses(gomock.Eq(batchID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetResponsesCommand(c, writer)
+	_ = cmd.Flags().Set("batch-id", batchID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Batch Responses:
+Batch ID: 5d883286-9480-463a-a738-9ddcfae65b8b
+Total Responses: 0
+
+No responses found for batch 5d883286-9480-463a-a738-9ddcfae65b8b
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetResponsesCommandHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := aitaskbuilder.TestInvalidBatchID
+	errorMessage := aitaskbuilder.ErrBatchNotFound
+
+	c.
+		EXPECT().
+		GetAITaskBuilderResponses(gomock.Eq(batchID)).
+		Return(nil, errors.New(errorMessage)).
+		AnyTimes()
+
+	cmd := aitaskbuilder.NewGetResponsesCommand(c, os.Stdout)
+	_ = cmd.Flags().Set("batch-id", batchID)
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestNewGetResponsesCommandRequiresBatchID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewGetResponsesCommand(c, os.Stdout)
+	err := cmd.RunE(cmd, nil)
+
+	if err == nil {
+		t.Fatal("expected error when batch-id is missing")
+	}
+
+	if !cmd.Flags().Changed("batch-id") {
+		expected := aitaskbuilder.ErrBatchIDRequired
+		if err.Error() != "error: "+expected {
+			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
+		}
+	}
+}
+
+func TestNewGetResponsesCommandHandlesResponseWithEmptyAnswer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "e0d498d3-09cc-4f11-b3ed-99b6753b0a2c"
+	createdAt := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	response := client.GetAITaskBuilderResponsesResponse{
+		Responses: []model.AITaskBuilderResponse{
+			{
+				ID:            "response-123",
+				CreatedAt:     createdAt,
+				BatchID:       batchID,
+				ParticipantID: "participant-456",
+				Response: model.AITaskBuilderResponseData{
+					InstructionID: "instruction-001",
+					Type:          "text",
+					Answer:        "", // empty answer
+				},
+				TaskID: "task-456",
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderResponses(gomock.Eq(batchID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetResponsesCommand(c, writer)
+	_ = cmd.Flags().Set("batch-id", batchID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Batch Responses:
+Batch ID: e0d498d3-09cc-4f11-b3ed-99b6753b0a2c
+Total Responses: 1
+
+Response 1:
+  ID: response-123
+  Participant ID: participant-456
+  Task ID: task-456
+  Created At: 2024-01-01 12:00:00
+  Response:
+    Instruction ID: instruction-001
+    Type: text
+    Answer: 
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -140,6 +140,21 @@ func (mr *MockAPIMockRecorder) GetAITaskBuilderBatches(workspaceID interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatches", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatches), workspaceID)
 }
 
+// GetAITaskBuilderResponses mocks base method.
+func (m *MockAPI) GetAITaskBuilderResponses(batchID string) (*client.GetAITaskBuilderResponsesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAITaskBuilderResponses", batchID)
+	ret0, _ := ret[0].(*client.GetAITaskBuilderResponsesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAITaskBuilderResponses indicates an expected call of GetAITaskBuilderResponses.
+func (mr *MockAPIMockRecorder) GetAITaskBuilderResponses(batchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderResponses", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderResponses), batchID)
+}
+
 // GetCampaigns mocks base method.
 func (m *MockAPI) GetCampaigns(workspaceID string, limit, offset int) (*client.ListCampaignsResponse, error) {
 	m.ctrl.T.Helper()

--- a/model/ai_task_builder.go
+++ b/model/ai_task_builder.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// AITaskBuilderBatch represents an AI task builder batch.
+// AITaskBuilderBatch represents an AI Task Builder batch.
 type AITaskBuilderBatch struct {
 	ID                    string      `json:"id"`
 	CreatedAt             time.Time   `json:"created_at"`
@@ -20,7 +20,7 @@ type AITaskBuilderBatch struct {
 	TaskDetails           TaskDetails `json:"task_details"`
 }
 
-// AITaskBuilderBatchStatus represents the status of an AI task builder batch.
+// AITaskBuilderBatchStatus represents the status of an AI Task Builder batch.
 type AITaskBuilderBatchStatus struct {
 	Status AITaskBuilderBatchStatusEnum `json:"status"`
 }
@@ -36,6 +36,23 @@ type TaskDetails struct {
 	TaskName         string `json:"task_name"`
 	TaskIntroduction string `json:"task_introduction"`
 	TaskSteps        string `json:"task_steps"`
+}
+
+// AITaskBuilderResponse represents a response from an AI Task Builder batch task.
+type AITaskBuilderResponse struct {
+	ID            string                    `json:"id"`
+	CreatedAt     time.Time                 `json:"created_at"`
+	BatchID       string                    `json:"batch_id"`
+	ParticipantID string                    `json:"participant_id"`
+	Response      AITaskBuilderResponseData `json:"response"`
+	TaskID        string                    `json:"task_id"`
+}
+
+// AITaskBuilderResponseData represents the response data structure.
+type AITaskBuilderResponseData struct {
+	InstructionID string `json:"instruction_id"`
+	Type          string `json:"type"`
+	Answer        string `json:"answer"`
 }
 
 type AITaskBuilderBatchStatusEnum string

--- a/model/ai_task_builder.go
+++ b/model/ai_task_builder.go
@@ -41,18 +41,38 @@ type TaskDetails struct {
 // AITaskBuilderResponse represents a response from an AI Task Builder batch task.
 type AITaskBuilderResponse struct {
 	ID            string                    `json:"id"`
-	CreatedAt     time.Time                 `json:"created_at"`
 	BatchID       string                    `json:"batch_id"`
 	ParticipantID string                    `json:"participant_id"`
-	Response      AITaskBuilderResponseData `json:"response"`
 	TaskID        string                    `json:"task_id"`
+	CorrelationID string                    `json:"correlation_id"`
+	SubmissionID  string                    `json:"submission_id"`
+	Metadata      map[string]string         `json:"metadata"`
+	Response      AITaskBuilderResponseData `json:"response"`
+	CreatedAt     time.Time                 `json:"created_at"`
+	SchemaVersion int                       `json:"schema_version"`
 }
 
 // AITaskBuilderResponseData represents the response data structure.
+// This is a discriminated union based on the Type field.
 type AITaskBuilderResponseData struct {
-	InstructionID string `json:"instruction_id"`
-	Type          string `json:"type"`
-	Answer        string `json:"answer"`
+	InstructionID string                      `json:"instruction_id"`
+	Type          AITaskBuilderResponseType   `json:"type"`
+	Text          *string                     `json:"text,omitempty"`   // For free_text and multiple_choice_with_free_text
+	Answer        []AITaskBuilderAnswerOption `json:"answer,omitempty"` // For multiple_choice and multiple_choice_with_free_text
+}
+
+// AITaskBuilderResponseType represents the type of response.
+type AITaskBuilderResponseType string
+
+const (
+	AITaskBuilderResponseTypeFreeText                   AITaskBuilderResponseType = "free_text"
+	AITaskBuilderResponseTypeMultipleChoice             AITaskBuilderResponseType = "multiple_choice"
+	AITaskBuilderResponseTypeMultipleChoiceWithFreeText AITaskBuilderResponseType = "multiple_choice_with_free_text"
+)
+
+// AITaskBuilderAnswerOption represents an answer option for multiple choice responses.
+type AITaskBuilderAnswerOption struct {
+	Value string `json:"value"`
 }
 
 type AITaskBuilderBatchStatusEnum string


### PR DESCRIPTION
Adds command and functionality for retrieving task responses for a batch run on AI Task Builder.

```
prolific aitaskbuilder getresponses --batch-id 7ba881d3-4b05-4fd9-a513-5c7718ce991b
Task Builder Batch Responses:
Batch ID: 7ba881d3-4b05-4fd9-a513-5c7718ce991b
Total Responses: 2

Response 1:
  ID: 5a298c19-ba8b-4bbf-9448-c733bcd6e8f7
  Batch ID: 7ba881d3-4b05-4fd9-a513-5c7718ce991b
  Participant ID: 222ac47c-16bb-4309-8ce3-782d34514b14
  Task ID: fd5fb5c3-cdfc-4481-a696-3856d1f6461f
  Correlation ID: 12341d1e53de978123456789
  Submission ID: 60030ee26cb64e9aa3449cs
  Schema Version: 2
  Created At: 2025-08-06 11:54:07
  Response:
    Instruction ID: 90101221-8a29-4825-a90a-c6f832b2f85a
    Type: free_text
    Text:

Response 2:
  ID: 7a19bce1-6638-405c-ad29-b05f98d74067
  Batch ID: 7ba881d3-4b05-4fd9-a513-5c7718ce991b
  Participant ID: 655dc56476dc7511c7cd6095
  Task ID: 4ca3f667-5cc2-4276-9b6f-792b2b126a46
  Correlation ID: beb0408fd51a41fe951beb321
  Submission ID: 5caf62f9c8ad465c817eb6e4
  Schema Version: 2
  Created At: 2025-08-06 11:54:07
  Response:
    Instruction ID: b83432b6-c334-45e2-a05d-88517ea4837b
    Type: multiple_choice
    Selected Options:
      - Fair
```