### PR TITLE
feat(#206): :sparkles: add get dataset stats AI Task Builder command to CLI Close : #206

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -66,6 +66,7 @@ type API interface {
 	GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error)
 	GetAITaskBuilderBatches(workspaceID string) (*GetAITaskBuilderBatchesResponse, error)
 	GetAITaskBuilderResponses(batchID string) (*GetAITaskBuilderResponsesResponse, error)
+	GetAITaskBuilderDatasetStatus(datasetID string) (*GetAITaskBuilderDatasetStatusResponse, error)
 }
 
 // Client is responsible for interacting with the Prolific API.
@@ -636,6 +637,18 @@ func (c *Client) GetAITaskBuilderResponses(batchID string) (*GetAITaskBuilderRes
 	var response GetAITaskBuilderResponsesResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/batches/%s/responses", batchID)
+	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+	return &response, nil
+}
+
+// GetAITaskBuilderDatasetStatus will return the status of an AI Task Builder dataset.
+func (c *Client) GetAITaskBuilderDatasetStatus(datasetID string) (*GetAITaskBuilderDatasetStatusResponse, error) {
+	var response GetAITaskBuilderDatasetStatusResponse
+
+	url := fmt.Sprintf("/api/v1/data-collection/datasets/%s/status", datasetID)
 	_, err := c.Execute(http.MethodGet, url, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)

--- a/client/responses.go
+++ b/client/responses.go
@@ -208,6 +208,11 @@ type GetAITaskBuilderResponsesResponse struct {
 	Meta    ResponseMeta                  `json:"meta"`
 }
 
+// GetAITaskBuilderDatasetStatusResponse is the response for the get AI Task Builder dataset status endpoint.
+type GetAITaskBuilderDatasetStatusResponse struct {
+	Status string `json:"status"`
+}
+
 // ResponseMeta contains metadata about the response.
 type ResponseMeta struct {
 	Count int `json:"count"`

--- a/cmd/aitaskbuilder/aitaskbuilder.go
+++ b/cmd/aitaskbuilder/aitaskbuilder.go
@@ -20,6 +20,7 @@ func NewAITaskBuilderCommand(client client.API, w io.Writer) *cobra.Command {
 		NewGetBatchStatusCommand(client, w),
 		NewGetBatchesCommand(client, w),
 		NewGetResponsesCommand(client, w),
+		NewGetDatasetStatusCommand(client, w),
 	)
 
 	return cmd

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -2,6 +2,7 @@ package aitaskbuilder
 
 const (
 	// Error messages
-	ErrBatchIDRequired = "batch ID is required"
-	ErrBatchNotFound   = "batch not found"
+	ErrBatchIDRequired   = "batch ID is required"
+	ErrBatchNotFound     = "batch not found"
+	ErrDatasetIDRequired = "dataset ID is required"
 )

--- a/cmd/aitaskbuilder/get_batch_status.go
+++ b/cmd/aitaskbuilder/get_batch_status.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Similar patterns are expected for CLI commands
 package aitaskbuilder
 
 import (

--- a/cmd/aitaskbuilder/get_dataset_status.go
+++ b/cmd/aitaskbuilder/get_dataset_status.go
@@ -1,0 +1,74 @@
+//nolint:dupl // Similar patterns are expected for CLI commands
+package aitaskbuilder
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+type DatasetGetStatusOptions struct {
+	Args      []string
+	DatasetID string
+}
+
+func NewGetDatasetStatusCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts DatasetGetStatusOptions
+
+	cmd := &cobra.Command{
+		Use:   "getdatasetstatus",
+		Short: "Get an AI Task Builder dataset status",
+		Long: `Get the status of a specific AI Task Builder dataset
+
+This command allows you to retrieve the status of a specific AI Task Builder dataset by providing
+the dataset ID.
+
+The status of a dataset can transition to one of the following:
+
+• UNINITIALISED - This means that the dataset has been created, but no data has been uploaded to it yet.
+• PROCESSING - This means that the dataset is being processed into datapoints to use in the task configuration process.
+• READY - This means that the dataset is completely processed into datapoints and ready to be used within a batch.
+• ERROR - This means that something has gone wrong during processing and the data may not be usable.`,
+		Example: `
+Get an AI Task Builder dataset status:
+$ prolific aitaskbuilder getdatasetstatus -d <dataset_id>
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := renderAITaskBuilderDatasetStatus(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.DatasetID, "dataset-id", "d", "", "Dataset ID (required) - The ID of the dataset to retrieve.")
+
+	_ = cmd.MarkFlagRequired("dataset-id")
+
+	return cmd
+}
+
+func renderAITaskBuilderDatasetStatus(c client.API, opts DatasetGetStatusOptions, w io.Writer) error {
+	if opts.DatasetID == "" {
+		return errors.New(ErrDatasetIDRequired)
+	}
+
+	response, err := c.GetAITaskBuilderDatasetStatus(opts.DatasetID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "AI Task Builder Dataset Status:\n")
+	fmt.Fprintf(w, "Dataset ID: %s\n", opts.DatasetID)
+	fmt.Fprintf(w, "Status: %s\n", response.Status)
+
+	return nil
+}

--- a/cmd/aitaskbuilder/get_dataset_status_test.go
+++ b/cmd/aitaskbuilder/get_dataset_status_test.go
@@ -1,0 +1,264 @@
+package aitaskbuilder_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/aitaskbuilder"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+func TestNewGetDatasetStatusCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, os.Stdout)
+
+	use := "getdatasetstatus"
+	short := "Get an AI Task Builder dataset status"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewGetDatasetStatusCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	datasetID := "01954894-65b3-779e-aaf6-348698e23612"
+
+	response := client.GetAITaskBuilderDatasetStatusResponse{
+		Status: "READY",
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderDatasetStatus(gomock.Eq(datasetID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, writer)
+	_ = cmd.Flags().Set("dataset-id", datasetID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Dataset Status:
+Dataset ID: 01954894-65b3-779e-aaf6-348698e23612
+Status: READY
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetDatasetStatusCommandCallsAPIWithProcessingStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	datasetID := "01954894-65b3-779e-aaf6-348698e23613"
+
+	response := client.GetAITaskBuilderDatasetStatusResponse{
+		Status: "PROCESSING",
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderDatasetStatus(gomock.Eq(datasetID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, writer)
+	_ = cmd.Flags().Set("dataset-id", datasetID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Dataset Status:
+Dataset ID: 01954894-65b3-779e-aaf6-348698e23613
+Status: PROCESSING
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetDatasetStatusCommandCallsAPIWithUninitialisedStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	datasetID := "01954894-65b3-779e-aaf6-348698e23614"
+
+	response := client.GetAITaskBuilderDatasetStatusResponse{
+		Status: "UNINITIALISED",
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderDatasetStatus(gomock.Eq(datasetID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, writer)
+	_ = cmd.Flags().Set("dataset-id", datasetID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Dataset Status:
+Dataset ID: 01954894-65b3-779e-aaf6-348698e23614
+Status: UNINITIALISED
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetDatasetStatusCommandCallsAPIWithErrorStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	datasetID := "01954894-65b3-779e-aaf6-348698e23615"
+
+	response := client.GetAITaskBuilderDatasetStatusResponse{
+		Status: "ERROR",
+	}
+
+	c.
+		EXPECT().
+		GetAITaskBuilderDatasetStatus(gomock.Eq(datasetID)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, writer)
+	_ = cmd.Flags().Set("dataset-id", datasetID)
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `AI Task Builder Dataset Status:
+Dataset ID: 01954894-65b3-779e-aaf6-348698e23615
+Status: ERROR
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewGetDatasetStatusCommandHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	datasetID := "the-invalid-dataset-id"
+	errorMessage := "dataset not found"
+
+	c.
+		EXPECT().
+		GetAITaskBuilderDatasetStatus(gomock.Eq(datasetID)).
+		Return(nil, errors.New(errorMessage)).
+		AnyTimes()
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, os.Stdout)
+	_ = cmd.Flags().Set("dataset-id", datasetID)
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestNewGetDatasetStatusCommandRequiresDatasetID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, os.Stdout)
+	err := cmd.RunE(cmd, nil)
+
+	if err == nil {
+		t.Fatal("expected error when dataset-id is missing")
+	}
+
+	if !cmd.Flags().Changed("dataset-id") {
+		expected := aitaskbuilder.ErrDatasetIDRequired
+		if err.Error() != "error: "+expected {
+			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
+		}
+	}
+}
+
+func TestNewGetDatasetStatusCommandHelpText(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewGetDatasetStatusCommand(c, os.Stdout)
+
+	// Check that the long description contains status information
+	if !contains(cmd.Long, "UNINITIALISED") {
+		t.Fatal("expected long description to contain UNINITIALISED status")
+	}
+	if !contains(cmd.Long, "PROCESSING") {
+		t.Fatal("expected long description to contain PROCESSING status")
+	}
+	if !contains(cmd.Long, "READY") {
+		t.Fatal("expected long description to contain READY status")
+	}
+	if !contains(cmd.Long, "ERROR") {
+		t.Fatal("expected long description to contain ERROR status")
+	}
+
+	// Check example contains correct flag
+	if !contains(cmd.Example, "-d <dataset_id>") {
+		t.Fatal("expected example to contain '-d <dataset_id>' flag usage")
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || (len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsAt(s, substr))))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -155,6 +155,21 @@ func (mr *MockAPIMockRecorder) GetAITaskBuilderResponses(batchID interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderResponses", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderResponses), batchID)
 }
 
+// GetAITaskBuilderDatasetStatus mocks base method.
+func (m *MockAPI) GetAITaskBuilderDatasetStatus(datasetID string) (*client.GetAITaskBuilderDatasetStatusResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAITaskBuilderDatasetStatus", datasetID)
+	ret0, _ := ret[0].(*client.GetAITaskBuilderDatasetStatusResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAITaskBuilderDatasetStatus indicates an expected call of GetAITaskBuilderDatasetStatus.
+func (mr *MockAPIMockRecorder) GetAITaskBuilderDatasetStatus(datasetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderDatasetStatus", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderDatasetStatus), datasetID)
+}
+
 // GetCampaigns mocks base method.
 func (m *MockAPI) GetCampaigns(workspaceID string, limit, offset int) (*client.ListCampaignsResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
```
prolific aitaskbuilder getdatasetstatus -d aa8fffc0-b6a1-4cb1-bff6-b539e9e652f0
AI Task Builder Dataset Status:
Dataset ID: aa8fffc0-b6a1-4cb1-bff6-b539e9e652f0
Status: READY
```

allows users to check on the status of datasets being processed for annotation in AI Task Builder tasks

A dataset may consist of data in many files stored under one dataset id. It is used to store the data that is uploaded by the Data Collector.

The status of a dataset can transition to one of the following:

UNINITIALISED - This means that the dataset has been created, but no data has been uploaded to it yet.
PROCESSING - This means that the dataset is being processed into datapoints to use in the task configuration process.
READY - This means that the dataset is completely processed into datapoints and ready to be used within a batch.
ERROR - This means that something has gone wrong during processing and the data may not be usable.

[relevant API docs](https://docs.prolific.com/docs/api-docs/public/#tag/AI-Task-Builder)