### PR TITLE
feat(#226): :sparkles: add create dataset command to aitaskbuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## release-next
 
+- Add `aitaskbuilder create-dataset` command to create new datasets.
+
 ## 0.0.56
 
 - Add Apache 2 License.

--- a/client/client.go
+++ b/client/client.go
@@ -62,6 +62,7 @@ type API interface {
 	SendMessage(body, recipientID, studyID string) error
 	GetUnreadMessages() (*ListUnreadMessagesResponse, error)
 
+	CreateAITaskBuilderDataset(workspaceID string, payload CreateAITaskBuilderDatasetPayload) (*CreateAITaskBuilderDatasetResponse, error)
 	GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchResponse, error)
 	GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error)
 	GetAITaskBuilderBatches(workspaceID string) (*GetAITaskBuilderBatchesResponse, error)
@@ -653,5 +654,23 @@ func (c *Client) GetAITaskBuilderDatasetStatus(datasetID string) (*GetAITaskBuil
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}
+	return &response, nil
+}
+
+// CreateAITaskBuilderDataset will create a new AI Task Builder dataset.
+func (c *Client) CreateAITaskBuilderDataset(workspaceID string, payload CreateAITaskBuilderDatasetPayload) (*CreateAITaskBuilderDatasetResponse, error) {
+	var response CreateAITaskBuilderDatasetResponse
+
+	url := fmt.Sprintf("/api/v1/data-collection/workspaces/%s/datasets/", workspaceID)
+	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	if httpResponse.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(httpResponse.Body)
+		return nil, fmt.Errorf("unable to create dataset: %v", string(body))
+	}
+
 	return &response, nil
 }

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -6,3 +6,8 @@ type SendMessagePayload struct {
 	StudyID     string `json:"study_id"`
 	Body        string `json:"body"`
 }
+
+// CreateAITaskBuilderDatasetPayload represents the request for creating a dataset
+type CreateAITaskBuilderDatasetPayload struct {
+	Name string `json:"name"`
+}

--- a/client/responses.go
+++ b/client/responses.go
@@ -213,6 +213,11 @@ type GetAITaskBuilderDatasetStatusResponse struct {
 	Status string `json:"status"`
 }
 
+// CreateAITaskBuilderDatasetResponse is the response for creating a dataset
+type CreateAITaskBuilderDatasetResponse struct {
+	Dataset model.Dataset `json:"dataset"`
+}
+
 // ResponseMeta contains metadata about the response.
 type ResponseMeta struct {
 	Count int `json:"count"`

--- a/cmd/aitaskbuilder/aitaskbuilder.go
+++ b/cmd/aitaskbuilder/aitaskbuilder.go
@@ -16,6 +16,7 @@ func NewAITaskBuilderCommand(client client.API, w io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		NewCreateDatasetCommand(client, w),
 		NewGetBatchCommand(client, w),
 		NewGetBatchStatusCommand(client, w),
 		NewGetBatchesCommand(client, w),

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -2,7 +2,10 @@ package aitaskbuilder
 
 const (
 	// Error messages
-	ErrBatchIDRequired   = "batch ID is required"
-	ErrBatchNotFound     = "batch not found"
-	ErrDatasetIDRequired = "dataset ID is required"
+	ErrBatchIDRequired     = "batch ID is required"
+	ErrBatchNotFound       = "batch not found"
+	ErrDatasetIDRequired   = "dataset ID is required"
+	ErrDatasetNotFound     = "dataset not found"
+	ErrNameRequired        = "name is required"
+	ErrWorkspaceIDRequired = "workspace ID is required"
 )

--- a/cmd/aitaskbuilder/create_dataset.go
+++ b/cmd/aitaskbuilder/create_dataset.go
@@ -1,0 +1,81 @@
+package aitaskbuilder
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+// CreateDatasetOptions holds the options for creating a dataset
+type CreateDatasetOptions struct {
+	Args        []string
+	Name        string
+	WorkspaceID string
+}
+
+// NewCreateDatasetCommand creates a new command for creating datasets
+func NewCreateDatasetCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts CreateDatasetOptions
+
+	cmd := &cobra.Command{
+		Use:   "create-dataset",
+		Short: "Create an AI Task Builder dataset",
+		Long: `Create a new AI Task Builder dataset
+
+Provide a name and workspace ID to create a new dataset in your workspace.`,
+		Example: `
+Create a dataset:
+$ prolific aitaskbuilder create-dataset -n "test" -w <workspace_id>
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := createAITaskBuilderDataset(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Name, "name", "n", "", "Name of the dataset (required)")
+	flags.StringVarP(&opts.WorkspaceID, "workspace-id", "w", "", "Workspace ID (required)")
+
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("workspace-id")
+
+	return cmd
+}
+
+// createAITaskBuilderDataset will create a new dataset
+func createAITaskBuilderDataset(c client.API, opts CreateDatasetOptions, w io.Writer) error {
+	// Validate required fields
+	if opts.Name == "" {
+		return errors.New(ErrNameRequired)
+	}
+	if opts.WorkspaceID == "" {
+		return errors.New(ErrWorkspaceIDRequired)
+	}
+
+	// Build payload from options
+	payload := client.CreateAITaskBuilderDatasetPayload{
+		Name: opts.Name,
+	}
+
+	// Call API to create
+	response, err := c.CreateAITaskBuilderDataset(opts.WorkspaceID, payload)
+	if err != nil {
+		return err
+	}
+
+	// Output success with ID
+	fmt.Fprintf(w, "Created dataset: %s\n", response.Dataset.ID)
+	fmt.Fprintf(w, "Total datapoint count: %d\n", response.Dataset.TotalDatapointCount)
+
+	return nil
+}

--- a/cmd/aitaskbuilder/create_dataset_test.go
+++ b/cmd/aitaskbuilder/create_dataset_test.go
@@ -1,0 +1,149 @@
+package aitaskbuilder_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/aitaskbuilder"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewCreateDatasetCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewCreateDatasetCommand(c, os.Stdout)
+
+	use := "create-dataset"
+	short := "Create an AI Task Builder dataset"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewCreateDatasetCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	workspaceID := "workspace-123"
+	payload := client.CreateAITaskBuilderDatasetPayload{
+		Name: "Test Dataset",
+	}
+
+	response := client.CreateAITaskBuilderDatasetResponse{
+		Dataset: model.Dataset{
+			ID:                  "dataset-456",
+			TotalDatapointCount: 0,
+		},
+	}
+
+	c.
+		EXPECT().
+		CreateAITaskBuilderDataset(gomock.Eq(workspaceID), gomock.Eq(payload)).
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewCreateDatasetCommand(c, writer)
+	_ = cmd.Flags().Set("name", "Test Dataset")
+	_ = cmd.Flags().Set("workspace-id", "workspace-123")
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `Created dataset: dataset-456
+Total datapoint count: 0
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewCreateDatasetCommandHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	workspaceID := "invalid-workspace"
+	payload := client.CreateAITaskBuilderDatasetPayload{
+		Name: "Test Dataset",
+	}
+
+	errorMessage := "workspace not found"
+
+	c.
+		EXPECT().
+		CreateAITaskBuilderDataset(gomock.Eq(workspaceID), gomock.Eq(payload)).
+		Return(nil, errors.New(errorMessage)).
+		AnyTimes()
+
+	cmd := aitaskbuilder.NewCreateDatasetCommand(c, os.Stdout)
+	_ = cmd.Flags().Set("name", "Test Dataset")
+	_ = cmd.Flags().Set("workspace-id", "invalid-workspace")
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestNewCreateDatasetCommandRequiresName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewCreateDatasetCommand(c, os.Stdout)
+	_ = cmd.Flags().Set("workspace-id", "workspace-123")
+	err := cmd.RunE(cmd, nil)
+
+	if err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+
+	if !cmd.Flags().Changed("name") {
+		expected := aitaskbuilder.ErrNameRequired
+		if err.Error() != "error: "+expected {
+			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
+		}
+	}
+}
+
+func TestNewCreateDatasetCommandRequiresWorkspaceID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewCreateDatasetCommand(c, os.Stdout)
+	_ = cmd.Flags().Set("name", "Test Dataset")
+	err := cmd.RunE(cmd, nil)
+
+	if err == nil {
+		t.Fatal("expected error when workspace-id is missing")
+	}
+
+	if !cmd.Flags().Changed("workspace-id") {
+		expected := aitaskbuilder.ErrWorkspaceIDRequired
+		if err.Error() != "error: "+expected {
+			t.Fatalf("expected error to contain '%s', got '%s'", expected, err.Error())
+		}
+	}
+}

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -35,6 +35,21 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
+// CreateAITaskBuilderDataset mocks base method.
+func (m *MockAPI) CreateAITaskBuilderDataset(workspaceID string, payload client.CreateAITaskBuilderDatasetPayload) (*client.CreateAITaskBuilderDatasetResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAITaskBuilderDataset", workspaceID, payload)
+	ret0, _ := ret[0].(*client.CreateAITaskBuilderDatasetResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAITaskBuilderDataset indicates an expected call of CreateAITaskBuilderDataset.
+func (mr *MockAPIMockRecorder) CreateAITaskBuilderDataset(workspaceID, payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAITaskBuilderDataset", reflect.TypeOf((*MockAPI)(nil).CreateAITaskBuilderDataset), workspaceID, payload)
+}
+
 // CreateProject mocks base method.
 func (m *MockAPI) CreateProject(workspaceID string, project model.Project) (*client.CreateProjectResponse, error) {
 	m.ctrl.T.Helper()
@@ -45,7 +60,7 @@ func (m *MockAPI) CreateProject(workspaceID string, project model.Project) (*cli
 }
 
 // CreateProject indicates an expected call of CreateProject.
-func (mr *MockAPIMockRecorder) CreateProject(workspaceID, project any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateProject(workspaceID, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockAPI)(nil).CreateProject), workspaceID, project)
 }
@@ -60,7 +75,7 @@ func (m *MockAPI) CreateStudy(arg0 model.CreateStudy) (*model.Study, error) {
 }
 
 // CreateStudy indicates an expected call of CreateStudy.
-func (mr *MockAPIMockRecorder) CreateStudy(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateStudy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStudy", reflect.TypeOf((*MockAPI)(nil).CreateStudy), arg0)
 }
@@ -75,7 +90,7 @@ func (m *MockAPI) CreateWorkspace(workspace model.Workspace) (*client.CreateWork
 }
 
 // CreateWorkspace indicates an expected call of CreateWorkspace.
-func (mr *MockAPIMockRecorder) CreateWorkspace(workspace any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateWorkspace(workspace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkspace", reflect.TypeOf((*MockAPI)(nil).CreateWorkspace), workspace)
 }
@@ -90,7 +105,7 @@ func (m *MockAPI) DuplicateStudy(ID string) (*model.Study, error) {
 }
 
 // DuplicateStudy indicates an expected call of DuplicateStudy.
-func (mr *MockAPIMockRecorder) DuplicateStudy(ID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DuplicateStudy(ID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DuplicateStudy", reflect.TypeOf((*MockAPI)(nil).DuplicateStudy), ID)
 }
@@ -105,7 +120,7 @@ func (m *MockAPI) GetAITaskBuilderBatch(batchID string) (*client.GetAITaskBuilde
 }
 
 // GetAITaskBuilderBatch indicates an expected call of GetAITaskBuilderBatch.
-func (mr *MockAPIMockRecorder) GetAITaskBuilderBatch(batchID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetAITaskBuilderBatch(batchID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatch", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatch), batchID)
 }
@@ -120,7 +135,7 @@ func (m *MockAPI) GetAITaskBuilderBatchStatus(batchID string) (*client.GetAITask
 }
 
 // GetAITaskBuilderBatchStatus indicates an expected call of GetAITaskBuilderBatchStatus.
-func (mr *MockAPIMockRecorder) GetAITaskBuilderBatchStatus(batchID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetAITaskBuilderBatchStatus(batchID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatchStatus", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatchStatus), batchID)
 }
@@ -135,24 +150,9 @@ func (m *MockAPI) GetAITaskBuilderBatches(workspaceID string) (*client.GetAITask
 }
 
 // GetAITaskBuilderBatches indicates an expected call of GetAITaskBuilderBatches.
-func (mr *MockAPIMockRecorder) GetAITaskBuilderBatches(workspaceID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetAITaskBuilderBatches(workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatches", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatches), workspaceID)
-}
-
-// GetAITaskBuilderResponses mocks base method.
-func (m *MockAPI) GetAITaskBuilderResponses(batchID string) (*client.GetAITaskBuilderResponsesResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAITaskBuilderResponses", batchID)
-	ret0, _ := ret[0].(*client.GetAITaskBuilderResponsesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAITaskBuilderResponses indicates an expected call of GetAITaskBuilderResponses.
-func (mr *MockAPIMockRecorder) GetAITaskBuilderResponses(batchID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderResponses", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderResponses), batchID)
 }
 
 // GetAITaskBuilderDatasetStatus mocks base method.
@@ -165,9 +165,24 @@ func (m *MockAPI) GetAITaskBuilderDatasetStatus(datasetID string) (*client.GetAI
 }
 
 // GetAITaskBuilderDatasetStatus indicates an expected call of GetAITaskBuilderDatasetStatus.
-func (mr *MockAPIMockRecorder) GetAITaskBuilderDatasetStatus(datasetID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetAITaskBuilderDatasetStatus(datasetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderDatasetStatus", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderDatasetStatus), datasetID)
+}
+
+// GetAITaskBuilderResponses mocks base method.
+func (m *MockAPI) GetAITaskBuilderResponses(batchID string) (*client.GetAITaskBuilderResponsesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAITaskBuilderResponses", batchID)
+	ret0, _ := ret[0].(*client.GetAITaskBuilderResponsesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAITaskBuilderResponses indicates an expected call of GetAITaskBuilderResponses.
+func (mr *MockAPIMockRecorder) GetAITaskBuilderResponses(batchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderResponses", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderResponses), batchID)
 }
 
 // GetCampaigns mocks base method.
@@ -180,7 +195,7 @@ func (m *MockAPI) GetCampaigns(workspaceID string, limit, offset int) (*client.L
 }
 
 // GetCampaigns indicates an expected call of GetCampaigns.
-func (mr *MockAPIMockRecorder) GetCampaigns(workspaceID, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetCampaigns(workspaceID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCampaigns", reflect.TypeOf((*MockAPI)(nil).GetCampaigns), workspaceID, limit, offset)
 }
@@ -210,7 +225,7 @@ func (m *MockAPI) GetEvents(subscriptionID string, limit, offset int) (*client.L
 }
 
 // GetEvents indicates an expected call of GetEvents.
-func (mr *MockAPIMockRecorder) GetEvents(subscriptionID, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetEvents(subscriptionID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvents", reflect.TypeOf((*MockAPI)(nil).GetEvents), subscriptionID, limit, offset)
 }
@@ -225,7 +240,7 @@ func (m *MockAPI) GetFilterSet(ID string) (*model.FilterSet, error) {
 }
 
 // GetFilterSet indicates an expected call of GetFilterSet.
-func (mr *MockAPIMockRecorder) GetFilterSet(ID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetFilterSet(ID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilterSet", reflect.TypeOf((*MockAPI)(nil).GetFilterSet), ID)
 }
@@ -240,7 +255,7 @@ func (m *MockAPI) GetFilterSets(workspaceID string, limit, offset int) (*client.
 }
 
 // GetFilterSets indicates an expected call of GetFilterSets.
-func (mr *MockAPIMockRecorder) GetFilterSets(workspaceID, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetFilterSets(workspaceID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilterSets", reflect.TypeOf((*MockAPI)(nil).GetFilterSets), workspaceID, limit, offset)
 }
@@ -285,7 +300,7 @@ func (m *MockAPI) GetHookSecrets(workspaceID string) (*client.ListSecretsRespons
 }
 
 // GetHookSecrets indicates an expected call of GetHookSecrets.
-func (mr *MockAPIMockRecorder) GetHookSecrets(workspaceID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetHookSecrets(workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHookSecrets", reflect.TypeOf((*MockAPI)(nil).GetHookSecrets), workspaceID)
 }
@@ -300,7 +315,7 @@ func (m *MockAPI) GetHooks(workspaceID string, enabled bool, limit, offset int) 
 }
 
 // GetHooks indicates an expected call of GetHooks.
-func (mr *MockAPIMockRecorder) GetHooks(workspaceID, enabled, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetHooks(workspaceID, enabled, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHooks", reflect.TypeOf((*MockAPI)(nil).GetHooks), workspaceID, enabled, limit, offset)
 }
@@ -330,7 +345,7 @@ func (m *MockAPI) GetMessages(userID, createdAfter *string) (*client.ListMessage
 }
 
 // GetMessages indicates an expected call of GetMessages.
-func (mr *MockAPIMockRecorder) GetMessages(userID, createdAfter any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetMessages(userID, createdAfter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessages", reflect.TypeOf((*MockAPI)(nil).GetMessages), userID, createdAfter)
 }
@@ -345,7 +360,7 @@ func (m *MockAPI) GetParticipantGroup(groupID string) (*client.ViewParticipantGr
 }
 
 // GetParticipantGroup indicates an expected call of GetParticipantGroup.
-func (mr *MockAPIMockRecorder) GetParticipantGroup(groupID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetParticipantGroup(groupID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParticipantGroup", reflect.TypeOf((*MockAPI)(nil).GetParticipantGroup), groupID)
 }
@@ -360,7 +375,7 @@ func (m *MockAPI) GetParticipantGroups(projectID string, limit, offset int) (*cl
 }
 
 // GetParticipantGroups indicates an expected call of GetParticipantGroups.
-func (mr *MockAPIMockRecorder) GetParticipantGroups(projectID, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetParticipantGroups(projectID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParticipantGroups", reflect.TypeOf((*MockAPI)(nil).GetParticipantGroups), projectID, limit, offset)
 }
@@ -375,7 +390,7 @@ func (m *MockAPI) GetProject(ID string) (*model.Project, error) {
 }
 
 // GetProject indicates an expected call of GetProject.
-func (mr *MockAPIMockRecorder) GetProject(ID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetProject(ID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockAPI)(nil).GetProject), ID)
 }
@@ -390,7 +405,7 @@ func (m *MockAPI) GetProjects(workspaceID string, limit, offset int) (*client.Li
 }
 
 // GetProjects indicates an expected call of GetProjects.
-func (mr *MockAPIMockRecorder) GetProjects(workspaceID, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetProjects(workspaceID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockAPI)(nil).GetProjects), workspaceID, limit, offset)
 }
@@ -405,7 +420,7 @@ func (m *MockAPI) GetStudies(status, projectID string) (*client.ListStudiesRespo
 }
 
 // GetStudies indicates an expected call of GetStudies.
-func (mr *MockAPIMockRecorder) GetStudies(status, projectID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetStudies(status, projectID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudies", reflect.TypeOf((*MockAPI)(nil).GetStudies), status, projectID)
 }
@@ -420,7 +435,7 @@ func (m *MockAPI) GetStudy(ID string) (*model.Study, error) {
 }
 
 // GetStudy indicates an expected call of GetStudy.
-func (mr *MockAPIMockRecorder) GetStudy(ID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetStudy(ID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudy", reflect.TypeOf((*MockAPI)(nil).GetStudy), ID)
 }
@@ -435,7 +450,7 @@ func (m *MockAPI) GetSubmissions(ID string, limit, offset int) (*client.ListSubm
 }
 
 // GetSubmissions indicates an expected call of GetSubmissions.
-func (mr *MockAPIMockRecorder) GetSubmissions(ID, limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetSubmissions(ID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubmissions", reflect.TypeOf((*MockAPI)(nil).GetSubmissions), ID, limit, offset)
 }
@@ -465,7 +480,7 @@ func (m *MockAPI) GetWorkspaces(limit, offset int) (*client.ListWorkspacesRespon
 }
 
 // GetWorkspaces indicates an expected call of GetWorkspaces.
-func (mr *MockAPIMockRecorder) GetWorkspaces(limit, offset any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetWorkspaces(limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaces", reflect.TypeOf((*MockAPI)(nil).GetWorkspaces), limit, offset)
 }
@@ -479,7 +494,7 @@ func (m *MockAPI) SendMessage(body, recipientID, studyID string) error {
 }
 
 // SendMessage indicates an expected call of SendMessage.
-func (mr *MockAPIMockRecorder) SendMessage(body, recipientID, studyID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SendMessage(body, recipientID, studyID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessage", reflect.TypeOf((*MockAPI)(nil).SendMessage), body, recipientID, studyID)
 }
@@ -494,7 +509,7 @@ func (m *MockAPI) TransitionStudy(ID, action string) (*client.TransitionStudyRes
 }
 
 // TransitionStudy indicates an expected call of TransitionStudy.
-func (mr *MockAPIMockRecorder) TransitionStudy(ID, action any) *gomock.Call {
+func (mr *MockAPIMockRecorder) TransitionStudy(ID, action interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitionStudy", reflect.TypeOf((*MockAPI)(nil).TransitionStudy), ID, action)
 }
@@ -509,7 +524,7 @@ func (m *MockAPI) UpdateStudy(ID string, study model.UpdateStudy) (*model.Study,
 }
 
 // UpdateStudy indicates an expected call of UpdateStudy.
-func (mr *MockAPIMockRecorder) UpdateStudy(ID, study any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateStudy(ID, study interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStudy", reflect.TypeOf((*MockAPI)(nil).UpdateStudy), ID, study)
 }


### PR DESCRIPTION
<img width="915" height="461" alt="Screenshot 2025-11-01 at 20 54 35" src="https://github.com/user-attachments/assets/ce772bde-81d7-47ad-970f-3d8418343fc6" />

Enables creating datasets with a name in AI TaskBuilder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `aitaskbuilder create-dataset` CLI command and supporting client API to create AI Task Builder datasets.
> 
> - **CLI**
>   - **New command**: `aitaskbuilder create-dataset` to create datasets with `--name/-n` and `--workspace-id/-w`.
>   - Validates required flags; prints created dataset `ID` and `TotalDatapointCount`.
>   - Command registered under `aitaskbuilder`.
> - **Client API**
>   - Adds `CreateAITaskBuilderDataset(workspaceID, payload)` calling `POST /api/v1/data-collection/workspaces/{workspaceID}/datasets/`.
>   - Introduces `CreateAITaskBuilderDatasetPayload { name }` and `CreateAITaskBuilderDatasetResponse { dataset }`.
> - **Errors/Constants**
>   - Adds `ErrNameRequired` and `ErrWorkspaceIDRequired`.
> - **Tests/Mocks**
>   - New tests for create-dataset command; mock client extended with `CreateAITaskBuilderDataset`.
> - **Docs**
>   - CHANGELOG updated to note new command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dcdb99150f65f2b4cb74041ad71bb1a9d21b40b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->