### PR TITLE
fix(DCP-2017): Handle trailing newline in creds CSV file input

### DIFF
--- a/cmd/credentials/create.go
+++ b/cmd/credentials/create.go
@@ -3,7 +3,6 @@ package credentials
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/spf13/cobra"
@@ -37,27 +36,17 @@ $ prolific credentials create -w <workspace_id> "user1,pass1\nuser2,pass2\nuser3
 
 Create a credential pool from a file:
 $ prolific credentials create -w <workspace_id> -f credentials.csv
+$ prolific credentials create -w <workspace_id> -f docs/examples/credentials.csv
 
 File format example (credentials.csv):
-user1,pass1
-user2,pass2
-user3,pass3`,
+user1@example.com,p4ssw0rd1
+user2@example.com,p4ssw0rd2
+user3@example.com,p4ssw0rd3`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var credentials string
-
-			if opts.FilePath != "" {
-				// Read from file
-				data, err := os.ReadFile(opts.FilePath)
-				if err != nil {
-					return fmt.Errorf("unable to read file: %w", err)
-				}
-				credentials = string(data)
-			} else if len(args) > 0 {
-				// Use provided argument
-				credentials = args[0]
-			} else {
-				return fmt.Errorf("credentials must be provided either as an argument or via -f flag")
+			credentials, err := getCredentials(opts.FilePath, args, 0)
+			if err != nil {
+				return err
 			}
 
 			response, err := client.CreateCredentialPool(credentials, opts.WorkspaceID)

--- a/cmd/credentials/credentials.go
+++ b/cmd/credentials/credentials.go
@@ -1,11 +1,36 @@
 package credentials
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/spf13/cobra"
 )
+
+// getCredentials extracts credentials from either a file or command line arguments.
+// It handles reading from a file (via filePath), trimming trailing newlines that editors add,
+// or using a string argument at the specified index.
+func getCredentials(filePath string, args []string, argIndex int) (string, error) {
+	if filePath != "" {
+		// Read from file
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("unable to read file: %w", err)
+		}
+		// Trim trailing whitespace (including newlines) that editors add to files
+		return strings.TrimRight(string(data), "\n\r"), nil
+	}
+
+	if argIndex < len(args) {
+		// Use provided argument
+		return args[argIndex], nil
+	}
+
+	return "", fmt.Errorf("credentials must be provided either as an argument or via -f flag")
+}
 
 // NewCredentialsCommand creates a new `credentials` command
 func NewCredentialsCommand(client client.API, w io.Writer) *cobra.Command {

--- a/cmd/credentials/update.go
+++ b/cmd/credentials/update.go
@@ -3,7 +3,6 @@ package credentials
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/spf13/cobra"
@@ -36,28 +35,19 @@ $ prolific credentials update pool123 "user1,pass1\nuser2,pass2\nuser3,pass3"
 
 Update a credential pool from a file:
 $ prolific credentials update pool123 -f credentials.csv
+$ prolific credentials update pool123 -f docs/examples/credentials.csv
 
 File format example (credentials.csv):
-user1,pass1
-user2,pass2
-user3,pass3`,
+user1@example.com,p4ssw0rd1
+user2@example.com,p4ssw0rd2
+user3@example.com,p4ssw0rd3`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			credentialPoolID := args[0]
-			var credentials string
 
-			if opts.FilePath != "" {
-				// Read from file
-				data, err := os.ReadFile(opts.FilePath)
-				if err != nil {
-					return fmt.Errorf("unable to read file: %w", err)
-				}
-				credentials = string(data)
-			} else if len(args) > 1 {
-				// Use provided argument
-				credentials = args[1]
-			} else {
-				return fmt.Errorf("credentials must be provided either as an argument or via -f flag")
+			credentials, err := getCredentials(opts.FilePath, args, 1)
+			if err != nil {
+				return err
 			}
 
 			response, err := client.UpdateCredentialPool(credentialPoolID, credentials, "")

--- a/docs/examples/credentials.csv
+++ b/docs/examples/credentials.csv
@@ -1,0 +1,5 @@
+user1@example.com,p4ssw0rd1
+user2@example.com,p4ssw0rd2
+user3@example.com,p4ssw0rd3
+user4@example.com,p4ssw0rd4
+user5@example.com,p4ssw0rd5


### PR DESCRIPTION
# Problem

When reading credentials from a CSV file using the -f flag, when content included a trailing newline (\n) that text editors often add, this caused a mismatch with inline string credentials which don't have trailing newlines and ultimately failed to create creds

## Solution

Add some handling to file parsing before making API request.

## Docs

Also added a sample creds CSV + updated some command help.