### PR TITLE
feat(DCP-2018): Extend CLI to support credential list cmd

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,6 +38,7 @@ type API interface {
 	GetStudyCredentialsUsageReportCSV(ID string) (string, error)
 	CreateCredentialPool(credentials string, workspaceID string) (*CredentialPoolResponse, error)
 	UpdateCredentialPool(credentialPoolID string, credentials string, workspaceID string) (*CredentialPoolResponse, error)
+	ListCredentialPools(workspaceID string) (*ListCredentialPoolsResponse, error)
 
 	GetCampaigns(workspaceID string, limit, offset int) (*ListCampaignsResponse, error)
 
@@ -844,6 +845,23 @@ func (c *Client) UpdateCredentialPool(credentialPoolID string, credentials strin
 
 	endpointURL := fmt.Sprintf("/api/v1/credentials/%s/", credentialPoolID)
 	httpResponse, err := c.Execute(http.MethodPatch, endpointURL, payload, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: expected 200, got %d", httpResponse.StatusCode)
+	}
+
+	return &response, nil
+}
+
+// ListCredentialPools retrieves a list of credential pools for a specific workspace.
+func (c *Client) ListCredentialPools(workspaceID string) (*ListCredentialPoolsResponse, error) {
+	var response ListCredentialPoolsResponse
+
+	endpointURL := fmt.Sprintf("/api/v1/credentials/?workspace_id=%s", workspaceID)
+	httpResponse, err := c.Execute(http.MethodGet, endpointURL, nil, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/client/responses.go
+++ b/client/responses.go
@@ -288,3 +288,16 @@ type ResponseMeta struct {
 type CredentialPoolResponse struct {
 	CredentialPoolID string `json:"credential_pool_id"`
 }
+
+// CredentialPoolSummary represents a summary of a credential pool.
+type CredentialPoolSummary struct {
+	CredentialPoolID     string `json:"credential_pool_id"`
+	TotalCredentials     int    `json:"total_credentials"`
+	AvailableCredentials int    `json:"available_credentials"`
+	WorkspaceID          string `json:"workspace_id"`
+}
+
+// ListCredentialPoolsResponse is the response for listing credential pools.
+type ListCredentialPoolsResponse struct {
+	CredentialPools []CredentialPoolSummary `json:"credential_pools"`
+}

--- a/cmd/credentials/credentials.go
+++ b/cmd/credentials/credentials.go
@@ -43,6 +43,7 @@ func NewCredentialsCommand(client client.API, w io.Writer) *cobra.Command {
 	cmd.AddCommand(
 		NewCreateCommand(client, w),
 		NewUpdateCommand(client, w),
+		NewListCommand(client, w),
 	)
 
 	return cmd

--- a/cmd/credentials/list.go
+++ b/cmd/credentials/list.go
@@ -1,0 +1,64 @@
+package credentials
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+// ListOptions are the options for listing credential pools
+type ListOptions struct {
+	WorkspaceID string
+}
+
+// NewListCommand creates a new `credentials list` command to list credential pools for a workspace
+func NewListCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts ListOptions
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List credential pools for a workspace",
+		Long: `List all credential pools belonging to a specific workspace.
+
+Each credential pool summary includes:
+- Credential Pool ID
+- Total number of credentials
+- Number of available (unredeemed) credentials
+- Workspace ID
+
+Required:
+- Workspace ID (-w/--workspace-id): The workspace to list credential pools for`,
+		Example: `
+List all credential pools for a workspace:
+$ prolific credentials list -w <workspace_id>
+$ prolific credentials list --workspace-id 507f1f77bcf86cd799439011`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := client.ListCredentialPools(opts.WorkspaceID)
+			if err != nil {
+				return err
+			}
+
+			if len(response.CredentialPools) == 0 {
+				fmt.Fprintf(w, "No credential pools found for workspace %s\n", opts.WorkspaceID)
+				return nil
+			}
+
+			fmt.Fprintf(w, "Credential Pools for workspace %s:\n\n", opts.WorkspaceID)
+			for _, pool := range response.CredentialPools {
+				fmt.Fprintf(w, "Credential Pool ID: %s\n", pool.CredentialPoolID)
+				fmt.Fprintf(w, "  Total Credentials: %d\n", pool.TotalCredentials)
+				fmt.Fprintf(w, "  Available Credentials: %d\n", pool.AvailableCredentials)
+				fmt.Fprintf(w, "  Workspace ID: %s\n\n", pool.WorkspaceID)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.WorkspaceID, "workspace-id", "w", "", "Workspace ID (required)")
+	_ = cmd.MarkFlagRequired("workspace-id")
+
+	return cmd
+}

--- a/cmd/credentials/list_test.go
+++ b/cmd/credentials/list_test.go
@@ -1,0 +1,200 @@
+package credentials_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/credentials"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+func TestNewListCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := credentials.NewListCommand(c, os.Stdout)
+
+	use := "list"
+	short := "List credential pools for a workspace"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestListCredentialPools(t *testing.T) {
+	workspaceID := "workspace123"
+
+	tests := []struct {
+		name           string
+		workspaceID    string
+		mockReturn     *client.ListCredentialPoolsResponse
+		mockError      error
+		expectedOutput string
+		expectedError  string
+	}{
+		{
+			name:        "successful list with multiple pools",
+			workspaceID: workspaceID,
+			mockReturn: &client.ListCredentialPoolsResponse{
+				CredentialPools: []client.CredentialPoolSummary{
+					{
+						CredentialPoolID:     "cred_pool_12345",
+						TotalCredentials:     100,
+						AvailableCredentials: 75,
+						WorkspaceID:          workspaceID,
+					},
+					{
+						CredentialPoolID:     "cred_pool_67890",
+						TotalCredentials:     50,
+						AvailableCredentials: 50,
+						WorkspaceID:          workspaceID,
+					},
+				},
+			},
+			mockError: nil,
+			expectedOutput: `Credential Pools for workspace workspace123:
+
+Credential Pool ID: cred_pool_12345
+  Total Credentials: 100
+  Available Credentials: 75
+  Workspace ID: workspace123
+
+Credential Pool ID: cred_pool_67890
+  Total Credentials: 50
+  Available Credentials: 50
+  Workspace ID: workspace123
+
+`,
+			expectedError: "",
+		},
+		{
+			name:        "successful list with single pool",
+			workspaceID: workspaceID,
+			mockReturn: &client.ListCredentialPoolsResponse{
+				CredentialPools: []client.CredentialPoolSummary{
+					{
+						CredentialPoolID:     "cred_pool_12345",
+						TotalCredentials:     100,
+						AvailableCredentials: 75,
+						WorkspaceID:          workspaceID,
+					},
+				},
+			},
+			mockError: nil,
+			expectedOutput: `Credential Pools for workspace workspace123:
+
+Credential Pool ID: cred_pool_12345
+  Total Credentials: 100
+  Available Credentials: 75
+  Workspace ID: workspace123
+
+`,
+			expectedError: "",
+		},
+		{
+			name:        "no credential pools found",
+			workspaceID: workspaceID,
+			mockReturn: &client.ListCredentialPoolsResponse{
+				CredentialPools: []client.CredentialPoolSummary{},
+			},
+			mockError:      nil,
+			expectedOutput: "No credential pools found for workspace workspace123\n",
+			expectedError:  "",
+		},
+		{
+			name:           "workspace ID missing error",
+			workspaceID:    "",
+			mockReturn:     nil,
+			mockError:      nil,
+			expectedOutput: "",
+			expectedError:  "required flag(s) \"workspace-id\" not set",
+		},
+		{
+			name:           "service unavailable",
+			workspaceID:    workspaceID,
+			mockReturn:     nil,
+			mockError:      errors.New("request failed with status 502: credentials service unavailable"),
+			expectedOutput: "",
+			expectedError:  "request failed with status 502: credentials service unavailable",
+		},
+		{
+			name:           "forbidden error",
+			workspaceID:    workspaceID,
+			mockReturn:     nil,
+			mockError:      errors.New("request failed with status 403: user does not have permission"),
+			expectedOutput: "",
+			expectedError:  "request failed with status 403: user does not have permission",
+		},
+		{
+			name:           "bad request - workspace_id missing",
+			workspaceID:    workspaceID,
+			mockReturn:     nil,
+			mockError:      errors.New("request failed with status 400: workspace_id query parameter is required"),
+			expectedOutput: "",
+			expectedError:  "request failed with status 400: workspace_id query parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c := mock_client.NewMockAPI(ctrl)
+
+			// Only expect API call if we have workspace ID
+			if tt.workspaceID != "" {
+				c.EXPECT().
+					ListCredentialPools(tt.workspaceID).
+					Return(tt.mockReturn, tt.mockError).
+					Times(1)
+			}
+
+			var b bytes.Buffer
+			writer := bufio.NewWriter(&b)
+
+			cmd := credentials.NewListCommand(c, writer)
+			if tt.workspaceID != "" {
+				_ = cmd.Flags().Set("workspace-id", tt.workspaceID)
+			}
+
+			var err error
+			// For workspace ID missing test, need to use Execute() to trigger Cobra's flag validation
+			if tt.workspaceID == "" {
+				cmd.SetArgs([]string{})
+				err = cmd.Execute()
+			} else {
+				err = cmd.RunE(cmd, []string{})
+			}
+			writer.Flush()
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error '%s', got nil", tt.expectedError)
+				}
+				if err.Error() != tt.expectedError {
+					t.Fatalf("expected error '%s', got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			actual := b.String()
+			if actual != tt.expectedOutput {
+				t.Fatalf("expected output:\n'%s'\n\ngot:\n'%s'", tt.expectedOutput, actual)
+			}
+		})
+	}
+}

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -575,6 +575,21 @@ func (mr *MockAPIMockRecorder) GetWorkspaces(limit, offset interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaces", reflect.TypeOf((*MockAPI)(nil).GetWorkspaces), limit, offset)
 }
 
+// ListCredentialPools mocks base method.
+func (m *MockAPI) ListCredentialPools(workspaceID string) (*client.ListCredentialPoolsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCredentialPools", workspaceID)
+	ret0, _ := ret[0].(*client.ListCredentialPoolsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCredentialPools indicates an expected call of ListCredentialPools.
+func (mr *MockAPIMockRecorder) ListCredentialPools(workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCredentialPools", reflect.TypeOf((*MockAPI)(nil).ListCredentialPools), workspaceID)
+}
+
 // SendMessage mocks base method.
 func (m *MockAPI) SendMessage(body, recipientID, studyID string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

Implements the `credentials list` command to support the new list credential pools API endpoint. Allows users to view all credential pools for a workspace with summary information including total and available credentials.

## List credential pools

New command to list all credential pools belonging to a workspace.

```bash
# List all credential pools for a workspace
prolific credentials list -w <workspace_id>

# Example with workspace ID
prolific credentials list --workspace-id 507f1f77bcf86cd799439011
```

### Output

For each credential pool, displays:
- Credential Pool ID
- Total credentials count
- Available (unredeemed) credentials count
- Workspace ID

Example output:
```
Credential Pools for workspace 507f1f77bcf86cd799439011:

Credential Pool ID: cred_pool_12345
  Total Credentials: 100
  Available Credentials: 75
  Workspace ID: 507f1f77bcf86cd799439011

Credential Pool ID: cred_pool_67890
  Total Credentials: 50
  Available Credentials: 50
  Workspace ID: 507f1f77bcf86cd799439011
```

## Implementation

- Added `ListCredentialPools` method to client API interface
- Created `CredentialPoolSummary` and `ListCredentialPoolsResponse` types
- Implemented `credentials list` command with workspace ID validation
- Updated mock client for testing

## Testing

Unit tests cover:
- Successful listing with multiple pools
- Successful listing with single pool
- Empty results handling
- Required workspace ID validation
- Error handling (403 Forbidden, 502 Bad Gateway, 400 Bad Request)
