### PR TITLE
fix(#245): :bug: Resolves #245

### DIFF
--- a/cmd/study/list_test.go
+++ b/cmd/study/list_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
 	"github.com/prolific-oss/cli/cmd/study"
 	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
 )
 
 func TestNewViewCommand(t *testing.T) {
@@ -25,5 +27,35 @@ func TestNewViewCommand(t *testing.T) {
 
 	if cmd.Short != short {
 		t.Fatalf("expected use: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestListCommandPassesBothProjectIDAndStatusToGetStudies(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	projectID := "6655b8281cc82a88996f0bbb"
+	status := model.StatusUnpublished
+
+	studyResponse := client.ListStudiesResponse{
+		Results: []model.Study{},
+	}
+
+	mockClient.
+		EXPECT().
+		GetStudies(gomock.Eq(status), gomock.Eq(projectID)).
+		Return(&studyResponse, nil).
+		Times(1)
+
+	cmd := study.NewListCommand("list", mockClient, os.Stdout)
+
+	_ = cmd.Flags().Set("project", projectID)
+	_ = cmd.Flags().Set("status", status)
+	_ = cmd.Flags().Set("non-interactive", "true")
+
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
 }


### PR DESCRIPTION
allows passing project via -p and status via -s for finer grained filtering in both interactive and non interactive modes