### PR TITLE
chore: update changelog for 0.0.57 and document release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # CHANGELOG
 
-## next
-
-- Make it clear if a study is underpaying in the `study view` command.
-- Provide an `--underpaying` flag for the `study list` command to filter down to only underpaying studies.
-
 ## 0.0.57
 
 - Add `study credentials-report` command to download CSV report of credential usage for a study:
@@ -50,6 +45,11 @@
   - `DatasetStatus` for dataset statuses
   - `InstructionType` for instruction types
 - Use `ErrWorkspaceIDRequired` constant for consistent error handling
+- Make it clear if a study is underpaying in the `study view` command.
+- Provide an `--underpaying` flag for the `study list` command to filter down to only underpaying studies.
+- Add support for `go install github.com/prolific-oss/cli/cmd/prolific@latest`.
+- Add `owner` and `description` fields to `project create` command.
+- Fix study list filtering to allow project and status filters to be used together.
 
 ## 0.0.56
 

--- a/README.md
+++ b/README.md
@@ -135,3 +135,36 @@ You can download the binaries from the [release pages](https://github.com/prolif
 Once downloaded, be sure to put the binary in a folder that is referenced in your `$PATH`.
 
 </details>
+
+<details>
+<summary>Installation via Go Install</summary>
+
+```shell
+go install github.com/prolific-oss/cli/cmd/prolific@latest
+```
+
+</details>
+
+## Release Process
+
+Releases are managed via GitHub Releases and automated CI/CD.
+
+### 1. Update CHANGELOG.md
+
+Add your changes to the `CHANGELOG.md` file under a new version section (e.g., `## 0.0.58`).
+
+### 2. Create a GitHub Release
+
+1. Go to [Releases](https://github.com/prolific-oss/cli/releases)
+2. Click "Draft a new release"
+3. Create a new tag matching the version (e.g., `v0.0.58`)
+4. Title the release with the version number
+5. Publish the release
+
+### 3. Automated Build
+
+The release workflow automatically:
+- Builds binaries for multiple platforms (darwin, linux, windows, freebsd)
+- Uploads binaries to the GitHub Release as assets
+
+Users can then download binaries from the release page or use `go install`.


### PR DESCRIPTION
## Summary

Prepares the repository for the 0.0.57 release by consolidating all unreleased changes into the changelog and documenting the release process.

## Changes

### CHANGELOG.md
- Merged `## next` section into `## 0.0.57`
- Added missing features that were not documented:
  - `go install` support
  - `owner` and `description` fields for `project create`
  - Fix for project/status filter exclusivity in study list

### README.md
- Added "Installation via Go Install" section
- Added "Release Process" section documenting:
  - How to update CHANGELOG
  - How to create a GitHub Release
  - What the automated build does

## Context

The last release was v0.0.56 (October 27, 2025). Since then, 63 commits have been merged but v0.0.57 was never released. This PR ensures all changes are properly documented before the next release.