### PR TITLE
chore: add CLI command plan template for Claude Code

### DIFF
--- a/.claude/templates/cli-command-plan.md
+++ b/.claude/templates/cli-command-plan.md
@@ -1,0 +1,157 @@
+# {TICKET-NUMBER}: CLI {resource} {command} Command
+
+## Overview
+
+{Brief description of command purpose and context}
+
+## Command Type
+
+<!-- Select one: LIST | VIEW | CREATE | UPDATE | ACTION -->
+**Type**: {COMMAND_TYPE}
+
+## API Contract
+
+<!-- Provide ONE of the following: Bruno file OR inline contract -->
+
+### Option A: Bruno File
+<!-- Provide file path OR paste .bru contents directly -->
+```
+{path/to/request.bru OR paste .bru file contents here}
+```
+
+### Option B: Inline Contract
+
+**Example:**
+```
+GET /api/v1/data-collection/collections?workspace_id={id}&limit={n}&offset={n}
+
+Response 200:
+{
+  "results": [
+    {
+      "id": "uuid",
+      "name": "string",
+      "created_at": "ISO8601",
+      "created_by": "string",
+      "item_count": number
+    }
+  ],
+  "meta": { "count": number }
+}
+
+Response 404:
+{ "error": { "detail": "Workspace not found" } }
+```
+
+### Error Responses
+
+- 400: {when/why}
+- 404: {when/why}
+- 500: {when/why}
+
+## Flags to Support
+
+<!-- Check flags needed for this command -->
+- [ ] `--workspace` / `-w` - Workspace ID (required)
+- [ ] `--non-interactive` / `-n` - Table output to terminal
+- [ ] `--csv` / `-c` - CSV format output
+- [ ] `--json` - JSON format output
+- [ ] `--fields` / `-f` - Comma-separated field list
+- [ ] `--limit` - Pagination limit (default 200)
+- [ ] `--offset` - Pagination offset (default 0)
+- [ ] `--web` / `-W` - Open in browser (VIEW commands)
+- [ ] {custom flag}
+
+## Renderers Required
+
+<!-- LIST commands: select which renderers to implement -->
+<!-- VIEW commands: skip this section - use single Render function in ui/{resource}/view.go -->
+
+- [ ] InteractiveRenderer (bubbletea)
+- [ ] NonInteractiveRenderer (table)
+- [ ] CsvRenderer
+- [ ] JSONRenderer
+
+## Implementation Layers
+
+| Layer | File | Purpose |
+|-------|------|---------|
+| Model | `model/{resource}.go` | Go struct with JSON tags |
+| Response | `client/responses.go` | API response wrapper |
+| Client Interface | `client/client.go` | Add method to API interface |
+| Client Impl | `client/client.go` | Implement API method |
+| Parent Command | `cmd/{resource}/{resource}.go` | Group subcommands |
+| Command | `cmd/{resource}/{command}.go` | Cobra command + flags |
+| UI Renderers | `ui/{resource}/{command}.go` | Output formatters |
+| Mock | `mock_client/mock_client.go` | Test mock |
+| Tests | `cmd/{resource}/{command}_test.go` | Command tests |
+| UI Tests | `ui/{resource}/list_test.go` | Renderer tests (LIST commands only) |
+
+## Pre-implementation Tasks
+
+{Ask user if they wish to set up a feature branch, if yes carry out the following}
+
+- [ ] Stash any local changes: `git stash`
+- [ ] Checkout main and pull latest: `git checkout main && git pull`
+- [ ] Create feature branch: `git checkout -b {TICKET-NUMBER}-{resource}-{command}-command`
+
+## Implementation Tasks
+
+### 1. Model
+- [ ] Create `model/{resource}.go`
+  - Struct with json tags
+  - `FilterValue()`, `Title()`, `Description()` for bubbletea (LIST only)
+
+### 2. Client
+- [ ] Add response type to `client/responses.go`
+- [ ] Add method to `API` interface in `client/client.go`
+- [ ] Implement method on `Client` struct
+
+### 3. Commands
+- [ ] Create parent command `cmd/{resource}/{resource}.go` (if new resource)
+- [ ] Create `cmd/{resource}/{command}.go`
+  - Options struct
+  - `New{Command}Command()` function
+  - Flag definitions
+  - RunE implementation
+
+### 4. UI (command type specific)
+
+**LIST commands:**
+- [ ] Create `ui/{resource}/list.go`
+  - `ListUsedOptions` struct
+  - `ListStrategy` interface
+  - Renderer implementations (Interactive, NonInteractive, CSV, JSON)
+
+**VIEW commands:**
+- [ ] Create `ui/{resource}/view.go`
+  - Single `Render{Resource}()` function
+
+### 5. Mocks & Tests
+- [ ] Regenerate mock: `mockgen -source=client/client.go -destination=mock_client/mock_client.go -package=mock_client`
+- [ ] Create `cmd/{resource}/{command}_test.go`
+
+**LIST commands only:**
+- [ ] Create `ui/{resource}/list_test.go`
+
+**Note:** VIEW commands do NOT require separate UI tests. The command tests in `cmd/{resource}/{command}_test.go` exercise the `Render{Resource}()` function indirectly.
+
+### 6. Wire Up
+- [ ] Add command to `cmd/root.go`:
+  ```go
+  rootCmd.AddCommand({resource}.New{Resource}Command(c, os.Stdout))
+  ```
+
+## Reference Files
+
+| Pattern | File |
+|---------|------|
+| LIST command | `cmd/collection/list.go` |
+| LIST renderers | `ui/collection/list.go` |
+| VIEW command | `cmd/project/view.go` |
+| CREATE command | `cmd/project/create.go` |
+| UPDATE command | `cmd/credentials/update.go` |
+| ACTION command | `cmd/study/transition.go` |
+| Parent command | `cmd/collection/collection.go` |
+| Model | `model/collection.go` |
+| Client method | `client/client.go:GetCollections` |

--- a/README.md
+++ b/README.md
@@ -145,6 +145,42 @@ go install github.com/prolific-oss/cli/cmd/prolific@latest
 
 </details>
 
+## Development with Claude Code
+
+When implementing new CLI commands, use the structured planning template:
+
+### 1. Create Your Plan
+
+Duplicate the template and fill in the details for your command:
+
+```shell
+cp .claude/templates/cli-command-plan.md {TICKET-NUMBER}-{resource}-{command}.md
+```
+
+### 2. Fill in the Template
+
+Update the template with:
+- Command type (LIST/VIEW/CREATE/UPDATE/ACTION)
+- API contract (Bruno file path or inline spec)
+- Required flags
+- Implementation details
+
+### 3. Execute with Claude Code
+
+Run Claude Code with your plan file:
+
+```shell
+claude
+```
+
+Then reference your plan:
+
+```
+@{TICKET-NUMBER}-{resource}-{command}.md now do as it says
+```
+
+Claude will follow the structured checklist to implement the model, client, command, UI renderers, mocks, and tests.
+
 ## Release Process
 
 Releases are managed via GitHub Releases and automated CI/CD.


### PR DESCRIPTION
## Summary

Add a reusable template for planning CLI command implementations with Claude Code. This provides a structured approach to implementing new commands with consistent patterns.

## CLI Command Plan Template

A markdown template that guides Claude Code through implementing new CLI commands by providing:

- Command type selection (LIST, VIEW, CREATE, UPDATE, ACTION)
- API contract specification (Bruno file or inline)
- Flag and renderer checklists
- Implementation layer breakdown with file paths
- Pre-implementation and implementation task checklists
- Reference files for each command pattern

### Usage

Reference the template when asking Claude Code to implement a new CLI command:

```
>> claude
>> @DCP-2154-aitb-x-gmu-slice-1-cli-collection-get-command.md now do as it says
```

## Implementation

- Added `.claude/templates/cli-command-plan.md` - reusable template for CLI command planning
- Added `DCP-2154-aitb-x-gmu-slice-1-cli-collection-get-command.md` - example plan document showing template usage

## Caveats

Built around VIEW & LIST so will need extending for CREATE, ACTION etc.. but should be straight forward/obvious extension points.