### PR TITLE
feat(DCP-2153): rename items fields to collection_items and page_items

### DIFF
--- a/client/responses.go
+++ b/client/responses.go
@@ -280,7 +280,7 @@ type CreateAITaskBuilderCollectionResponse struct {
 	WorkspaceID   string                 `json:"workspace_id"`
 	SchemaVersion int                    `json:"schema_version"`
 	CreatedBy     string                 `json:"created_by"`
-	Items         []model.CollectionPage `json:"items"`
+	Items         []model.CollectionPage `json:"collection_items"`
 }
 
 // SetupAITaskBuilderBatchResponse is the response for setting up an AI Task Builder batch.

--- a/cmd/collection/create_collection.go
+++ b/cmd/collection/create_collection.go
@@ -38,10 +38,10 @@ An example of a JSON collection file:
 {
   "workspace_id": "67890abcdef12345678901234",
   "name": "example-collection",
-  "items": [
+  "collection_items": [
     {
       "order": 0,
-      "items": [
+      "page_items": [
         {
           "order": 0,
           "type": "free_text",
@@ -73,9 +73,9 @@ An example of a YAML collection file:
 ---
 workspace_id: 67890abcdef12345678901234
 name: example-collection
-items:
+collection_items:
   - order: 0
-    items:
+    page_items:
       - order: 0
         type: free_text
         description: How was your experience completing this task?

--- a/cmd/collection/create_collection_test.go
+++ b/cmd/collection/create_collection_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/prolific-oss/cli/model"
 )
 
-const items = `[
+const collectionItems = `[
     {
       "order": 0,
-      "items": [
+      "page_items": [
         {
           "order": 0,
           "type": "free_text",
@@ -76,8 +76,8 @@ func TestNewCreateCollectionCommandCallsAPIWithJSON(t *testing.T) {
 	templateContent := fmt.Sprintf(`{
   "workspace_id": "6716028cd934ced9bac18658",
   "name": "test-collection",
-	"items": %s
-}`, items)
+	"collection_items": %s
+}`, collectionItems)
 
 	err := os.WriteFile(templateFile, []byte(templateContent), 0600)
 	if err != nil {
@@ -155,9 +155,9 @@ func TestNewCreateCollectionCommandCallsAPIWithYAML(t *testing.T) {
 	templateFile := filepath.Join(tmpDir, "collection.yaml")
 	templateContent := `workspace_id: 6716028cd934ced9bac18658
 name: yaml-test-collection
-items:
+collection_items:
   - order: 0
-    items:
+    page_items:
       - order: 0
         type: free_text
         description: YAML test description
@@ -210,8 +210,8 @@ func TestNewCreateCollectionCommandHandlesAPIError(t *testing.T) {
 	templateContent := fmt.Sprintf(`{
   "workspace_id": "6716028cd934ced9bac18658",
   "name": "test-collection",
-  "items": %s
-}`, items)
+  "collection_items": %s
+}`, collectionItems)
 
 	err := os.WriteFile(templateFile, []byte(templateContent), 0600)
 	if err != nil {
@@ -262,8 +262,8 @@ func TestNewCreateCollectionCommandRequiresName(t *testing.T) {
 	templateFile := filepath.Join(tmpDir, "collection.json")
 	templateContent := fmt.Sprintf(`{
   "workspace_id": "6716028cd934ced9bac18658",
-  "items": %s
-}`, items)
+  "collection_items": %s
+}`, collectionItems)
 
 	err := os.WriteFile(templateFile, []byte(templateContent), 0600)
 	if err != nil {
@@ -293,8 +293,8 @@ func TestNewCreateCollectionCommandRequiresWorkspaceID(t *testing.T) {
 	templateFile := filepath.Join(tmpDir, "collection.json")
 	templateContent := fmt.Sprintf(`{
   "name": "test-collection",
-  "items": %s
-}`, items)
+  "collection_items": %s
+}`, collectionItems)
 
 	err := os.WriteFile(templateFile, []byte(templateContent), 0600)
 	if err != nil {
@@ -325,7 +325,7 @@ func TestNewCreateCollectionCommandRequiresItems(t *testing.T) {
 	templateContent := `{
   "name": "test-collection",
 	"workspace_id": "6716028cd934ced9bac18658",
-  "items": []
+  "collection_items": []
 }`
 
 	err := os.WriteFile(templateFile, []byte(templateContent), 0600)

--- a/docs/examples/collection.yaml
+++ b/docs/examples/collection.yaml
@@ -1,8 +1,8 @@
 workspace_id: 67890abcdef12345678901234
 name: example-collection
-items:
+collection_items:
   - order: 0
-    items:
+    page_items:
       - order: 0
         type: free_text
         description: How was your experience completing this task?

--- a/model/ai_task_builder.go
+++ b/model/ai_task_builder.go
@@ -129,13 +129,13 @@ const (
 type CreateAITaskBuilderCollection struct {
 	WorkspaceID string           `json:"workspace_id" mapstructure:"workspace_id"`
 	Name        string           `json:"name" mapstructure:"name"`
-	Items       []CollectionPage `json:"items" mapstructure:"items"`
+	Items       []CollectionPage `json:"collection_items" mapstructure:"collection_items"`
 }
 
 // CollectionPage represents a page in a collection containing instructions.
 type CollectionPage struct {
 	Order int                     `json:"order" mapstructure:"order"`
-	Items []CollectionInstruction `json:"items" mapstructure:"items"`
+	Items []CollectionInstruction `json:"page_items" mapstructure:"page_items"`
 }
 
 // CollectionInstruction represents an instruction item within a collection page.


### PR DESCRIPTION
## Summary

Renames the ambiguous `items` field names in the collection schema to be more descriptive and avoid confusion between collection-level and page-level items. This aligns CLI serialization with updated API schema changes.

## Schema Changes

| Location | Old Field | New Field |
|----------|-----------|-----------|
| Collection | `items` | `collection_items` |
| Page | `items` | `page_items` |

### Before
```yaml
items:
  - order: 0
    items:
      - order: 0
        type: free_text
```

### After
```yaml
collection_items:
  - order: 0
    page_items:
      - order: 0
        type: free_text
```

## Implementation

- Updated JSON/mapstructure tags in `model/ai_task_builder.go` for `CreateAITaskBuilderCollection` and `CollectionPage` structs
- Updated response struct in `client/responses.go`
- Updated example templates in `docs/examples/collection.yaml`
- Updated help text examples in `cmd/collection/create_collection.go`

## Testing

Unit tests cover:
- Collection creation with JSON and YAML templates
- Required field validation (name, workspace_id, collection_items)
- API error handling
- Invalid input handling