### PR TITLE
fix(DCP-2153): remove item_count from collection detail view

### DIFF
--- a/cmd/collection/get_test.go
+++ b/cmd/collection/get_test.go
@@ -134,7 +134,6 @@ func TestGetCommandOutputContainsCollectionDetails(t *testing.T) {
 		"My Test Collection",
 		testCollectionID,
 		"user@example.com",
-		"25",
 	}
 
 	for _, expected := range expectedStrings {

--- a/ui/collection/view.go
+++ b/ui/collection/view.go
@@ -65,7 +65,6 @@ func RenderCollection(collection *model.Collection, w io.Writer) error {
 	content += fmt.Sprintf("ID:         %s\n", collection.ID)
 	content += fmt.Sprintf("Created by: %s\n", collection.CreatedBy)
 	content += fmt.Sprintf("Created at: %s\n", collection.CreatedAt.Format("2006-01-02 15:04:05"))
-	content += fmt.Sprintf("Item count: %d\n", collection.ItemCount)
 
 	_, err := fmt.Fprint(w, content)
 	return err
@@ -77,7 +76,6 @@ func renderCollectionString(collection model.Collection) string {
 	content += fmt.Sprintf("ID:         %s\n", collection.ID)
 	content += fmt.Sprintf("Created by: %s\n", collection.CreatedBy)
 	content += fmt.Sprintf("Created at: %s\n", collection.CreatedAt.Format("2006-01-02 15:04:05"))
-	content += fmt.Sprintf("Item count: %d\n", collection.ItemCount)
 
 	return content
 }


### PR DESCRIPTION
## Summary

Removes `item_count` from the collection detail view as it's not returned by the single collection GET endpoint (only available in list endpoint responses).

## Changes

- Removed `item_count` display from `RenderCollection` and `renderCollectionString` in `ui/collection/view.go`
- Updated test expectations in `cmd/collection/get_test.go`

## Context

The list endpoint returns `item_count`:
```json
{
  "results": [{"id": "...", "name": "...", "item_count": 1, ...}]
}
```

The single GET endpoint does not:
```json
{"id": "...", "name": "...", "created_at": "...", ...}
```

This was causing the detail view to show `Item count: 0` for all collections.

## Testing

- `go test ./cmd/collection/...` passes
- `go test ./ui/collection/...` passes