### PR TITLE
chore: update early access banner to use help center chat URL

### DIFF
--- a/cmd/collection/constants.go
+++ b/cmd/collection/constants.go
@@ -9,6 +9,6 @@ const (
 	ErrWorkspaceNotFound       = "workspace not found"
 
 	// Feature access constants for AI Task Builder Collections (see DCP-2152)
-	FeatureNameAITBCollection         = "AI Task Builder Collections"
-	FeatureContactEmailAITBCollection = "support@prolific.com"
+	FeatureNameAITBCollection       = "AI Task Builder Collections"
+	FeatureContactURLAITBCollection = "https://researcher-help.prolific.com/en/"
 )

--- a/cmd/collection/create_collection.go
+++ b/cmd/collection/create_collection.go
@@ -99,7 +99,7 @@ collection_items:
 			err := createCollection(c, opts, w)
 			if err != nil {
 				if shared.IsFeatureNotEnabledError(err) {
-					ui.RenderFeatureAccessMessage(FeatureNameAITBCollection, FeatureContactEmailAITBCollection)
+					ui.RenderFeatureAccessMessage(FeatureNameAITBCollection, FeatureContactURLAITBCollection)
 					return nil
 				}
 				return fmt.Errorf("error: %s", err.Error())

--- a/cmd/collection/get.go
+++ b/cmd/collection/get.go
@@ -45,7 +45,7 @@ $ prolific collection get 123456789
 			coll, err := c.GetCollection(opts.Args[0])
 			if err != nil {
 				if shared.IsFeatureNotEnabledError(err) {
-					ui.RenderFeatureAccessMessage(FeatureNameAITBCollection, FeatureContactEmailAITBCollection)
+					ui.RenderFeatureAccessMessage(FeatureNameAITBCollection, FeatureContactURLAITBCollection)
 					return nil
 				}
 				return fmt.Errorf("error: %s", err.Error())

--- a/cmd/collection/list.go
+++ b/cmd/collection/list.go
@@ -89,7 +89,7 @@ The fields you can use are:
 
 			if err != nil {
 				if shared.IsFeatureNotEnabledError(err) {
-					ui.RenderFeatureAccessMessage(FeatureNameAITBCollection, FeatureContactEmailAITBCollection)
+					ui.RenderFeatureAccessMessage(FeatureNameAITBCollection, FeatureContactURLAITBCollection)
 					return nil
 				}
 				return fmt.Errorf("error: %s", err.Error())

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -69,12 +69,12 @@ func RenderHighlightedText(text string) string {
 // RenderFeatureAccessMessage renders a styled early-access feature message to stderr.
 // This is used when a feature is gated behind a feature flag and returns 404 feature not enabled errors.
 // Output goes to stderr so it doesn't interfere with JSON/CSV output piping.
-func RenderFeatureAccessMessage(featureName, contactEmail string) {
+func RenderFeatureAccessMessage(featureName, contactURL string) {
 	warningStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("#FFA500"))
 
-	emailStyle := lipgloss.NewStyle().
+	urlStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("#00BFFF"))
 
@@ -87,7 +87,7 @@ func RenderFeatureAccessMessage(featureName, contactEmail string) {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintf(os.Stderr, "%s is an early-access feature that may be enabled on your workspace upon request.\n", featureName)
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "To request access or contribute towards the feature's roadmap, get in touch at %s.\n", emailStyle.Render(contactEmail))
+	fmt.Fprintf(os.Stderr, "To request access or contribute towards the feature's roadmap, visit our help center at %s and drop us a message in the chat.\n", urlStyle.Render(contactURL))
 	fmt.Fprintln(os.Stderr, "Your activation request will be reviewed by our team.")
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, betaStyle.Render("Note: This feature is under active development and you may encounter bugs."))


### PR DESCRIPTION
## Summary

Updates the early access feature banner to direct users to the help center chatbot instead of the support email address. This provides a better support experience for users requesting access to gated features like AI Task Builder Collections.

## Changes

The banner message now reads:

```
To request access or contribute towards the feature's roadmap, visit our help center at https://researcher-help.prolific.com/en/ and drop us a message in the chat.
```

Previously it directed users to email `support@prolific.com`.

<img width="979" height="121" alt="Screenshot 2026-01-12 at 14 01 51" src="https://github.com/user-attachments/assets/effcb36e-3720-4d50-bc4e-8f34cbffb8d4" />

## Implementation

- Renamed `FeatureContactEmailAITBCollection` to `FeatureContactURLAITBCollection` in `cmd/collection/constants.go`
- Updated `RenderFeatureAccessMessage()` in `ui/ui.go` to accept a URL and render the new message format
- Updated all callers in collection commands (`list.go`, `get.go`, `create_collection.go`)

## Testing

- Existing unit tests pass
- Manual verification of banner output