### PR TITLE
Correctly define the go workflow badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <hr />
 
-![GitHub Badge](https://github.com/prolific-oss/cli/workflows/Go/badge.svg)
+![GitHub Badge](https://github.com/prolific-oss/cli/actions/workflows/go.yml/badge.svg)
 
 CLI application for getting information out of [Prolific](https://www.prolific.com) about your research studies.
 


### PR DESCRIPTION
The image currently shows as failing, which is incorrect. Followed the docs [here](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge)