### PR TITLE
chore(DCP-2416): fix golangci-lint v2.10.1 gosec taint analysis failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,13 @@ linters:
     - unparam
     - unused
     - whitespace
+  settings:
+    gosec:
+      config:
+        # Customise G101 pattern to remove "cred" which false-positives on
+        # domain terms like CredentialPoolID (an identifier, not a secret).
+        G101:
+          pattern: "(?i)passwd|pass|password|pwd|secret|token|pw|apiKey|bearer"
   exclusions:
     generated: lax
     presets:
@@ -29,6 +36,17 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # G703 (path traversal) false-positives on test temp files.
+      - linters: [gosec]
+        text: "G703"
+        path: '_test\.go'
+      # docs/scripts/ is a documentation example that invokes a local CLI
+      # binary with exec args (not shell expansion), uses constant paths,
+      # and writes to stderr. Taint analysis rules are false positives here.
+      - linters: [gosec]
+        text: "G70[235]"
+        path: 'docs/scripts/'
     paths:
       - third_party$
       - builtin$

--- a/client/client.go
+++ b/client/client.go
@@ -145,7 +145,7 @@ func (c *Client) Execute(method, url string, body any, response any) (*http.Resp
 		fmt.Println(request)
 	}
 
-	httpResponse, err := c.Client.Do(request)
+	httpResponse, err := c.Client.Do(request) //nolint:gosec // G704: URL constructed from user-configured API base
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aitaskbuilder/upload_dataset.go
+++ b/cmd/aitaskbuilder/upload_dataset.go
@@ -121,6 +121,6 @@ func uploadFileToPresignedURL(filePath, uploadURL string) error {
 
 	request.Header.Set("Content-Type", "multipart/form-data")
 	client := &http.Client{}
-	_, err = client.Do(request)
+	_, err = client.Do(request) //nolint:gosec // G704: URL from API-provided presigned upload URL
 	return err
 }

--- a/cmd/study/set_credential_pool_test.go
+++ b/cmd/study/set_credential_pool_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // testCredPoolID is a test fixture representing a credential pool ID in the format {workspace_id}_{uuid}
-const testCredPoolID = "679271425fe00981084a5f58_a856d700-c495-11f0-adce-338d4126f6e8" //nolint:gosec
+const testCredPoolID = "679271425fe00981084a5f58_a856d700-c495-11f0-adce-338d4126f6e8"
 
 func TestNewSetCredentialPoolCommandRendersBasicUsage(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/ui/study/list_test.go
+++ b/ui/study/list_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // testCredPoolID is a test fixture representing a credential pool ID in the format {workspace_id}_{uuid}
-const testCredPoolID = "679271425fe00981084a5f58_a856d700-c495-11f0-adce-338d4126f6e8" //nolint:gosec
+const testCredPoolID = "679271425fe00981084a5f58_a856d700-c495-11f0-adce-338d4126f6e8"
 
 func TestCsvRendererRendersInCsvFormat(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Summary

golangci-lint v2.10.1 introduced gosec taint analysis rules (G702-G705) that flag pre-existing CLI patterns as false positives. This unblocks CI on all open PRs.

Rather than sprinkling `//nolint:gosec` across every call site, this handles the bulk of suppressions centrally via `.golangci.yml`:

- **G101:** Remove `cred` from pattern — false-positives on domain terms like `CredentialPoolID`
- **G702/G703/G705:** Exclude `docs/scripts/` — example script invoking local CLI with exec args, constant paths, stderr
- **G703:** Exclude test files — temp file cleanup

Only 2 `//nolint:gosec` directives remain where config-level exclusion isn't appropriate:

- **G704** in `client/client.go` and `upload_dataset.go` — SSRF false positive on user-configured API URLs

## Test plan

- [x] `golangci-lint run` — 0 issues (v2.10.1)
- [x] `go test ./...` — all pass