### PR TITLE
fix(DCP-2449): add omitempty to Filter struct fields 

### DIFF
--- a/model/filter.go
+++ b/model/filter.go
@@ -2,13 +2,13 @@ package model
 
 // Filter holds information about the filter that makes up a filter set
 type Filter struct {
-	ID                string            `json:"id" mapstructure:"id"`
+	ID                string            `json:"id,omitempty" mapstructure:"id"`
 	FilterID          string            `json:"filter_id" mapstructure:"filter_id"`
-	FilterTitle       string            `json:"title" mapstructure:"title"`
-	FilterDescription string            `json:"description" mapstructure:"description"`
-	Question          string            `json:"question" mapstructure:"question"`
-	Type              string            `json:"type" mapstructure:"type"`
-	DataType          string            `json:"data_type" mapstructure:"data_type"`
+	FilterTitle       string            `json:"title,omitempty" mapstructure:"title"`
+	FilterDescription string            `json:"description,omitempty" mapstructure:"description"`
+	Question          string            `json:"question,omitempty" mapstructure:"question"`
+	Type              string            `json:"type,omitempty" mapstructure:"type"`
+	DataType          string            `json:"data_type,omitempty" mapstructure:"data_type"`
 	Min               any               `json:"min,omitempty" mapstructure:"min"`
 	Max               any               `json:"max,omitempty" mapstructure:"max"`
 	Choices           map[string]string `json:"choices,omitempty" mapstructure:"choices"`


### PR DESCRIPTION
### Summary

  - Adds omitempty to Filter struct fields to support direct filter configuration in study creation

###  Problem

  When creating studies with inline filters (e.g., custom_allowlist), the CLI was serializing empty string values for unused Filter fields (title, description, question, type, data_type). The API rejected these empty fields with:

  The fields "{'type', 'question', 'data_type', 'description'}" do not exist on the document "Filter"

###  Solution

  Add omitempty to the JSON tags so empty fields are omitted during serialization. This allows users to specify only the required fields:

```
  "filters": [
    {
      "filter_id": "custom_allowlist",
      "selected_values": ["participant_id_1", "participant_id_2"]
    }
  ]
```

###  Test plan

  - Verified study creation with custom_allowlist filter works
  - Run make test to ensure no regressions

