### PR TITLE
chore(DCP-2449): update CHANGELOG for v0.0.59 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 # CHANGELOG
 
-## next
+## 0.0.59
 
-- Bump Go version to 1.26.
+### AI Task Builder
+
+- **Add `content_format` field for rich text:**
+  - Support `content_format` on collection rich text content blocks (e.g. `html`, `markdown`)
+  - Add typed `ContentFormat` constant and constants matching API (html/markdown)
+  - Collection create/update and examples (JSON/YAML) support the new field
+- **Create Collection study as draft:**
+  - Add `--draft` / `-d` flag to `aitaskbuilder collection publish` to create studies in draft/unpublished status without immediately publishing
+  - Reassign `-d` shorthand from `--description` to `--draft`; `--description` remains long-form only
+
+### Study Creation
+
+- **Fix filter serialization (DCP-2449):**
+  - Add `omitempty` to `Filter` struct fields so unused fields (title, description, question, type, data_type) are not sent as empty strings
+  - Enables direct filter configuration (e.g. custom_allowlist) in study creation requests without API rejection
+
+### Developer Experience
+
+- Bump Go version to 1.26 across the project (go.mod, CI, Docker)
+- Bump `slackapi/slack-github-action` from 2.0.0 to 2.1.1
+- Configure gosec in `.golangci.yml` for taint analysis false positives (G702–G705); add targeted nolint where needed
 
 ## 0.0.58
 
@@ -412,3 +432,4 @@ Initial release of the `prolific` application.
 - Ability to get your user account details.
 - Ability to list and filter studies.
 - Ability to render details about a study, and the submissions.
+


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the AI Task Builder and study creation features, as well as developer experience improvements. The most important changes include support for rich text content formatting, improved study publishing workflow, and a fix for filter serialization in study creation.

Enhancements to AI Task Builder:

* Added a `content_format` field to collection rich text content blocks, supporting formats like `html` and `markdown`, with typed constants and example support in JSON/YAML.
* Introduced a `--draft` / `-d` flag to the `aitaskbuilder collection publish` command, allowing studies to be created as drafts without immediate publishing; reassigned the `-d` shorthand from `--description` to `--draft`.

Study Creation improvements:

* Fixed filter serialization by adding `omitempty` to `Filter` struct fields, preventing empty strings from being sent and enabling direct filter configuration in study creation requests.

Developer experience updates:

* Bumped Go version to 1.26 across the project, including `go.mod`, CI, and Docker.
* Updated `slackapi/slack-github-action` from 2.0.0 to 2.1.1 and configured gosec taint analysis in `.golangci.yml`, adding targeted nolint annotations as needed.