### PR TITLE
fix: bump Go version in release workflow to match go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.2.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Release workflow (`release.yml`) had `go-version: 1.25.x` while `go.mod` requires `go >= 1.26.0`, causing the v0.0.59 release build to fail
- Bumps `go-version` to `1.26.x` to match `go.yml` CI workflow and `go.mod`

## Test plan
- [x] Verify CI passes on this PR
- [ ] Re-run the v0.0.59 release after merge