### PR TITLE
fix: correct ldflags module path and strip v prefix from version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOOS ?=
 ARCH ?=
 OUT_PATH=$(BUILD_DIR)/$(NAME)-$(GOOS)-$(GOARCH)
 GIT_RELEASE ?= $(shell git rev-parse --short HEAD)
+VERSION = $(GIT_RELEASE:v%=%)
 
 .PHONY: explain
 explain:
@@ -73,14 +74,14 @@ build: ## Build the application
 .PHONY: static
 static: ## Build the application
 	CGO_ENABLED=0 go build \
-		-ldflags "-extldflags -static -X github.com/$(GIT_ORG)/$(NAME)/version.GITCOMMIT=$(GIT_RELEASE)" \
+		-ldflags "-extldflags -static -X github.com/$(GIT_ORG)/cli/version.GITCOMMIT=$(VERSION)" \
 		-o $(NAME) ./cmd/prolific
 
 .PHONY: static-named
 static-named: ## Build the application with named outputs
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 \
 		go build \
-		-ldflags "-extldflags -static -X github.com/$(GIT_ORG)/$(NAME)/version.GITCOMMIT=$(GIT_RELEASE)" \
+		-ldflags "-extldflags -static -X github.com/$(GIT_ORG)/cli/version.GITCOMMIT=$(VERSION)" \
 		-o $(OUT_PATH) ./cmd/prolific
 
 	md5sum $(OUT_PATH) > $(OUT_PATH).md5 || md5 $(OUT_PATH) > $(OUT_PATH).md5


### PR DESCRIPTION
## Summary

Release binaries always reported `prolific version dev` because the ldflags targeted the wrong Go module path (`github.com/prolific-oss/prolific` instead of `github.com/prolific-oss/cli`). This also strips the `v` prefix from release tags so version output reads `prolific version 0.0.59` instead of `prolific version v0.0.59`.

## Implementation

- Fix ldflags `-X` path from `github.com/$(GIT_ORG)/$(NAME)/version.GITCOMMIT` to `github.com/$(GIT_ORG)/cli/version.GITCOMMIT` to match the actual Go module path
- Add `VERSION` variable that strips the `v` prefix from `GIT_RELEASE` using Make's substitution reference (`$(GIT_RELEASE:v%=%)`)
- Applies to both `static` and `static-named` build targets

## Version output

| Build | Before | After |
|-------|--------|-------|
| Release (`v0.0.59`) | `prolific version dev` | `prolific version 0.0.59` |
| Local dev | `prolific version dev` | `prolific version 8853acf` |

## Testing

- Verified `make static` with `GIT_RELEASE=v0.0.59` produces `prolific version 0.0.59`
- Verified `make static` without `GIT_RELEASE` produces `prolific version <short-hash>`