### PR TITLE
fix(DCP-2422): use explicit tag range instead of --latest in git-cliff

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,7 +61,7 @@ jobs:
         uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
         with:
           config: cliff.toml
-          args: --latest --tag ${{ steps.version.outputs.new_tag }} --strip header
+          args: ${{ steps.version.outputs.latest_tag }}..HEAD --tag ${{ steps.version.outputs.new_tag }} --strip header
         env:
           OUTPUT: CLIFF_NOTES.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Fixes duplicate release notes where v0.0.60 contained the same entries as v0.0.59. The `--latest` flag falls back to the previous tag range when all commits since the latest tag are skipped types (chore/ci), so we use an explicit `$LATEST_TAG..HEAD` range instead.

## Changes

- **create-release.yml** — Replace `--latest` with `${{ steps.version.outputs.latest_tag }}..HEAD` in the git-cliff args