### PR TITLE
ci(DCP-2422): fix CI triggers for bot-created release PRs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -119,6 +119,8 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -172,3 +174,12 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git push origin --delete "${PR_HEAD_REF}" || true
+
+  build-release:
+    needs: finalize-release
+    if: needs.finalize-release.result == 'success'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.finalize-release.outputs.tag }}
+    permissions:
+      contents: write

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 jobs:
   build:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,23 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
     steps:
+      - name: Determine tag
+        id: tag
+        run: |
+          TAG="${{ inputs.tag || github.event.release.tag_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Set up Go
         uses: actions/setup-go@v6.2.0
         with:
@@ -16,6 +27,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Get dependencies
         run: |
@@ -46,8 +59,8 @@ jobs:
 
             echo "\n\nBuilding binary for ${GOOS}/${ARCH}\n"
 
-            GIT_RELEASE=${{ github.event.release.tag_name }} GOOS=${GOOS} GOARCH=${ARCH} make static-named
+            GIT_RELEASE=${{ steps.tag.outputs.tag }} GOOS=${GOOS} GOARCH=${ARCH} make static-named
           done
 
-          gh release upload ${{ github.event.release.tag_name }} build/*
+          gh release upload ${{ steps.tag.outputs.tag }} build/*
 


### PR DESCRIPTION
## Summary

`GITHUB_TOKEN` actions don't trigger other workflows, causing two issues with the automated release flow:

1. **Build check stuck on release PRs** — `go.yml` only had `on: [push]`, so the bot's push never triggered it. Changed to `pull_request` + `push` on main.

2. **Binary upload won't fire** — `release.yml` triggers on `release: published`, but `gh release create` via `GITHUB_TOKEN` doesn't fire that event. Added `workflow_call` so `create-release.yml` calls it directly after finalize.

## Changes

- **go.yml** — `on: [push]` → `on: pull_request` + `push: branches: [main]`
- **release.yml** — Added `workflow_call` trigger with `tag` input, resolves tag from either caller or release event
- **create-release.yml** — Added `build-release` job that calls `release.yml` after finalize completes