### PR TITLE
ci(DCP-2422): use GitHub App token for release PR creation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,11 +24,19 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -90,7 +98,7 @@ jobs:
 
       - name: Create release branch and PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEW_TAG="${{ steps.version.outputs.new_tag }}"
           BRANCH="release/${NEW_TAG}"


### PR DESCRIPTION
## Summary

`GITHUB_TOKEN` suppresses `push` and `pull_request` events, preventing the Build check from triggering on bot-created release PRs. This switches to a GitHub App token so events fire normally and the real build runs.

## Changes

- Added `actions/create-github-app-token@v1` step to mint a short-lived token
- Checkout uses the app token so `git push` triggers workflow events
- `gh pr create` uses the app token so the PR event triggers the Build check

## Prerequisites

Before merging, a GitHub App must be created and installed:

1. **Create a GitHub App** on the `prolific-oss` org (Settings → Developer settings → GitHub Apps)
   - Permissions: Contents (R/W), Pull requests (R/W)
   - Webhook: disabled
   - Install on the `cli` repo only

2. **Add repo secrets** to `prolific-oss/cli` (Settings → Secrets → Actions):
   - `RELEASE_APP_ID` — the App ID from the app's settings page
   - `RELEASE_APP_PRIVATE_KEY` — generate and download from the app's settings page

## Testing

- Merge, then trigger the release workflow via `workflow_dispatch`
- Verify the Build check runs on the created release PR