### PR TITLE
feat(#300): add invitations support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -60,6 +60,8 @@ type API interface {
 	GetWorkspaces(limit, offset int) (*ListWorkspacesResponse, error)
 	CreateWorkspace(workspace model.Workspace) (*CreateWorkspacesResponse, error)
 
+	CreateInvitation(invitation model.CreateInvitation) (*CreateInvitationResponse, error)
+
 	GetProjects(workspaceID string, limit, offset int) (*ListProjectsResponse, error)
 	CreateProject(workspaceID string, project model.Project) (*CreateProjectResponse, error)
 	GetProject(ID string) (*model.Project, error)
@@ -542,6 +544,24 @@ func (c *Client) CreateWorkspace(workspace model.Workspace) (*CreateWorkspacesRe
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
 		return nil, fmt.Errorf("unable to create workspace: %v", string(body))
+	}
+
+	return &response, nil
+}
+
+// CreateInvitation will create invitations for the given email addresses
+func (c *Client) CreateInvitation(invitation model.CreateInvitation) (*CreateInvitationResponse, error) {
+	var response CreateInvitationResponse
+
+	url := "/api/v1/invitations/"
+	httpResponse, err := c.Execute(http.MethodPost, url, invitation, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	if httpResponse.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(httpResponse.Body)
+		return nil, fmt.Errorf("unable to create invitation: %v", string(body))
 	}
 
 	return &response, nil

--- a/client/responses.go
+++ b/client/responses.go
@@ -313,6 +313,11 @@ type ListCredentialPoolsResponse struct {
 	CredentialPools []CredentialPoolSummary `json:"credential_pools"`
 }
 
+// CreateInvitationResponse is the response for creating invitations.
+type CreateInvitationResponse struct {
+	Invitations []model.Invitation `json:"invitations"`
+}
+
 // ListCollectionsResponse is the response for the collections API.
 type ListCollectionsResponse struct {
 	Results []model.Collection `json:"results"`

--- a/cmd/invitation/create.go
+++ b/cmd/invitation/create.go
@@ -1,0 +1,106 @@
+package invitation
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/model"
+	"github.com/spf13/cobra"
+)
+
+var validRoles = []string{"WORKSPACE_ADMIN", "WORKSPACE_COLLABORATOR"}
+
+// CreateOptions are the options to be able to create an invitation.
+type CreateOptions struct {
+	Args      []string
+	Workspace string
+	Emails    []string
+	Role      string
+}
+
+// NewCreateCommand creates a new command for creating invitations.
+func NewCreateCommand(commandName string, client client.API, w io.Writer) *cobra.Command {
+	var opts CreateOptions
+
+	cmd := &cobra.Command{
+		Use:   commandName,
+		Short: "Create workspace invitations",
+		Long: `Create invitations to invite users to collaborate on a workspace
+
+Invitations are sent to the provided email addresses with the specified role.
+The role determines whether the invitee will be a workspace admin or collaborator.
+`,
+		Example: `
+To invite a user as a collaborator
+$ prolific invitation create -w 60d9aa5fa100c40b8c3fac61 -e user@example.com -r WORKSPACE_COLLABORATOR
+
+To invite multiple users as admins
+$ prolific invitation create -w 60d9aa5fa100c40b8c3fac61 -e user1@example.com -e user2@example.com -r WORKSPACE_ADMIN
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := createInvitation(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Workspace, "workspace", "w", "", "The ID of the workspace to invite users to.")
+	flags.StringArrayVarP(&opts.Emails, "email", "e", nil, "Email address to invite (can be specified multiple times).")
+	flags.StringVarP(&opts.Role, "role", "r", "", "The role for the invitee: WORKSPACE_ADMIN or WORKSPACE_COLLABORATOR.")
+
+	return cmd
+}
+
+// createInvitation will create invitations for the given emails
+func createInvitation(client client.API, opts CreateOptions, w io.Writer) error {
+	if opts.Workspace == "" {
+		return errors.New("workspace is required")
+	}
+
+	if len(opts.Emails) == 0 {
+		return errors.New("at least one email is required")
+	}
+
+	if opts.Role == "" {
+		return errors.New("role is required")
+	}
+
+	if !isValidRole(opts.Role) {
+		return fmt.Errorf("invalid role %q: must be one of %s", opts.Role, strings.Join(validRoles, ", "))
+	}
+
+	invitation := model.CreateInvitation{
+		Association: opts.Workspace,
+		Emails:      opts.Emails,
+		Role:        opts.Role,
+	}
+
+	response, err := client.CreateInvitation(invitation)
+	if err != nil {
+		return err
+	}
+
+	for _, inv := range response.Invitations {
+		fmt.Fprintf(w, "Invited %s as %s\n", inv.Invitee.Email, inv.Role)
+	}
+
+	return nil
+}
+
+func isValidRole(role string) bool {
+	for _, r := range validRoles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/invitation/create_test.go
+++ b/cmd/invitation/create_test.go
@@ -1,0 +1,265 @@
+package invitation_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/invitation"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewCreateCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := invitation.NewCreateCommand("create", c, os.Stdout)
+
+	use := "create"
+	short := "Create workspace invitations"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestCreateCommandErrorsIfNoWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("email", "user@example.com")
+	_ = cmd.Flags().Set("role", "WORKSPACE_COLLABORATOR")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: workspace is required"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestCreateCommandErrorsIfNoEmail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("workspace", "60d9aa5fa100c40b8c3fac61")
+	_ = cmd.Flags().Set("role", "WORKSPACE_COLLABORATOR")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: at least one email is required"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestCreateCommandErrorsIfNoRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("workspace", "60d9aa5fa100c40b8c3fac61")
+	_ = cmd.Flags().Set("email", "user@example.com")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: role is required"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestCreateCommandErrorsIfInvalidRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("workspace", "60d9aa5fa100c40b8c3fac61")
+	_ = cmd.Flags().Set("email", "user@example.com")
+	_ = cmd.Flags().Set("role", "INVALID_ROLE")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := `error: invalid role "INVALID_ROLE": must be one of WORKSPACE_ADMIN, WORKSPACE_COLLABORATOR`
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestCreateCommandCreatesInvitation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	r := client.CreateInvitationResponse{
+		Invitations: []model.Invitation{
+			{
+				Association: "60d9aa5fa100c40b8c3fac61",
+				Invitee: model.Invitee{
+					Email: "user@example.com",
+				},
+				InvitedBy: "abc123",
+				Status:    "INVITED",
+				Role:      "WORKSPACE_COLLABORATOR",
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		Return(&r, nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("workspace", "60d9aa5fa100c40b8c3fac61")
+	_ = cmd.Flags().Set("email", "user@example.com")
+	_ = cmd.Flags().Set("role", "WORKSPACE_COLLABORATOR")
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	expected := fmt.Sprintf("Invited %s as %s\n", "user@example.com", "WORKSPACE_COLLABORATOR")
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestCreateCommandCreatesMultipleInvitations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	r := client.CreateInvitationResponse{
+		Invitations: []model.Invitation{
+			{
+				Invitee: model.Invitee{Email: "user1@example.com"},
+				Role:    "WORKSPACE_ADMIN",
+			},
+			{
+				Invitee: model.Invitee{Email: "user2@example.com"},
+				Role:    "WORKSPACE_ADMIN",
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		Return(&r, nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("workspace", "60d9aa5fa100c40b8c3fac61")
+	_ = cmd.Flags().Set("email", "user1@example.com")
+	_ = cmd.Flags().Set("email", "user2@example.com")
+	_ = cmd.Flags().Set("role", "WORKSPACE_ADMIN")
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	expected := "Invited user1@example.com as WORKSPACE_ADMIN\nInvited user2@example.com as WORKSPACE_ADMIN\n"
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestCreateCommandHandlesFailureToCreateInvitation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		CreateInvitation(gomock.Any()).
+		Return(nil, errors.New("unable to create invitation")).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := invitation.NewCreateCommand("create", c, writer)
+	_ = cmd.Flags().Set("workspace", "60d9aa5fa100c40b8c3fac61")
+	_ = cmd.Flags().Set("email", "user@example.com")
+	_ = cmd.Flags().Set("role", "WORKSPACE_COLLABORATOR")
+	err := cmd.RunE(cmd, nil)
+
+	expected := "error: unable to create invitation"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}

--- a/cmd/invitation/invitation.go
+++ b/cmd/invitation/invitation.go
@@ -1,0 +1,27 @@
+package invitation
+
+import (
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+// NewInvitationCommand creates a new `invitation` command
+func NewInvitationCommand(client client.API, w io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invitation",
+		Short: "Manage workspace invitations",
+		Long: `Manage invitations on Prolific
+
+Invitations are issued to invite users to collaborate or become admins of a
+shared workspace. Each invitation contains an association to a workspace and
+a role that determines the invitee's permissions.
+`,
+	}
+
+	cmd.AddCommand(
+		NewCreateCommand("create", client, w),
+	)
+	return cmd
+}

--- a/cmd/invitation/invitation_test.go
+++ b/cmd/invitation/invitation_test.go
@@ -1,0 +1,29 @@
+package invitation_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/cmd/invitation"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+func TestNewInvitationCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock_client.NewMockAPI(ctrl)
+
+	cmd := invitation.NewInvitationCommand(client, os.Stdout)
+
+	use := "invitation"
+	short := "Manage workspace invitations"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prolific-oss/cli/cmd/filters"
 	"github.com/prolific-oss/cli/cmd/filtersets"
 	"github.com/prolific-oss/cli/cmd/hook"
+	"github.com/prolific-oss/cli/cmd/invitation"
 	"github.com/prolific-oss/cli/cmd/message"
 	"github.com/prolific-oss/cli/cmd/participantgroup"
 	"github.com/prolific-oss/cli/cmd/project"
@@ -77,6 +78,7 @@ func NewRootCommand() *cobra.Command {
 		filters.NewListCommand(&client, w),
 		filtersets.NewFilterSetCommand(&client, w),
 		hook.NewHookCommand(&client, w),
+		invitation.NewInvitationCommand(&client, w),
 		message.NewMessageCommand(&client, w),
 		participantgroup.NewParticipantCommand(&client, w),
 		project.NewProjectCommand(&client, w),

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -139,6 +139,21 @@ func (mr *MockAPIMockRecorder) CreateCredentialPool(credentials, workspaceID int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCredentialPool", reflect.TypeOf((*MockAPI)(nil).CreateCredentialPool), credentials, workspaceID)
 }
 
+// CreateInvitation mocks base method.
+func (m *MockAPI) CreateInvitation(invitation model.CreateInvitation) (*client.CreateInvitationResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInvitation", invitation)
+	ret0, _ := ret[0].(*client.CreateInvitationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateInvitation indicates an expected call of CreateInvitation.
+func (mr *MockAPIMockRecorder) CreateInvitation(invitation interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInvitation", reflect.TypeOf((*MockAPI)(nil).CreateInvitation), invitation)
+}
+
 // CreateProject mocks base method.
 func (m *MockAPI) CreateProject(workspaceID string, project model.Project) (*client.CreateProjectResponse, error) {
 	m.ctrl.T.Helper()

--- a/model/invitation.go
+++ b/model/invitation.go
@@ -1,0 +1,25 @@
+package model
+
+// Invitee represents the user being invited.
+type Invitee struct {
+	ID    *string `json:"id"`
+	Name  *string `json:"name"`
+	Email string  `json:"email"`
+}
+
+// Invitation represents an invitation to collaborate on a workspace.
+type Invitation struct {
+	Association string  `json:"association"`
+	Invitee     Invitee `json:"invitee"`
+	InvitedBy   string  `json:"invited_by"`
+	Status      string  `json:"status"`
+	InviteLink  string  `json:"invite_link"`
+	Role        string  `json:"role"`
+}
+
+// CreateInvitation is the request body for creating invitations.
+type CreateInvitation struct {
+	Association string   `json:"association"`
+	Emails      []string `json:"emails"`
+	Role        string   `json:"role"`
+}


### PR DESCRIPTION
## Summary
- Add `invitation create` command to invite users to workspaces via the [Invitations API](https://docs.prolific.com/api-reference/invitations/create-invitation)
- Supports inviting one or multiple email addresses with a specified role (`WORKSPACE_ADMIN` or `WORKSPACE_COLLABORATOR`)
- Includes model, client method, response type, mock, and full test coverage

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet` passes clean
- [x] New invitation tests cover: missing workspace, missing email, missing role, invalid role, single invite, multiple invites, API error propagation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new CLI subcommand and corresponding client/model types to call the Invitations API; changes are additive and covered by unit tests, with low blast radius outside the updated `client.API` interface.
> 
> **Overview**
> Adds support for creating workspace invitations via a new `prolific invitation create` command, allowing one or more `--email` values plus a required `--workspace` and role (`WORKSPACE_ADMIN`/`WORKSPACE_COLLABORATOR`).
> 
> Extends the API client with `CreateInvitation` (POST `/api/v1/invitations/`) and introduces `model.Invitation`/`model.CreateInvitation` plus `CreateInvitationResponse`; wires the new `invitation` command into the root command and updates the GoMock client with tests covering validation, multi-invite output, and API error propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea682339c68559c0ff42dea879f4f0f92731025d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->