### PR TITLE
chore(DCP-2422): update changelog for v0.0.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 0.0.60
+
+- Maintenance and dependency updates
+
 ## 0.0.59
 
 ### AI Task Builder


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with v0.0.60 entry generated via `make changelog VERSION=0.0.60`

## Next steps

After merge, create a GitHub Release with tag `v0.0.60` to trigger the binary build workflow.