### PR TITLE
ci: fix dependabot commit messages to match conventional format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: 'GHA'
+      prefix: 'chore(deps)'
 
   # Maintain dependencies for docker
   - package-ecosystem: 'docker'
@@ -14,7 +14,7 @@ updates:
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: 'docker'
+      prefix: 'chore(deps)'
 
   # Maintain dependencies for go
   - package-ecosystem: 'gomod'
@@ -22,7 +22,7 @@ updates:
     schedule:
       interval: 'daily'
     commit-message:
-      prefix: 'gomod'
+      prefix: 'chore(deps)'
     groups:
       development-dependencies:
         dependency-type: 'development'


### PR DESCRIPTION
## Summary

- Change dependabot `commit-message.prefix` from ecosystem-specific names (`GHA`, `docker`, `gomod`) to `chore(deps)` so PRs pass the commit message validation workflow

## Context

All 5 open dependabot PRs (#342-#346) fail the "Validate commit messages" check because their prefixes (`GHA:`, `docker:`, `gomod:`) don't match the conventional commit pattern. After merging this, dependabot will need to recreate or rebase those PRs to pick up the new prefix.

## Test plan

- [x] Verify commit message validation passes in CI
- [x] After merge, close and reopen one dependabot PR to confirm new format