### PR TITLE
chore: update changelog for v0.0.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 0.0.61
+
+### Study
+
+- Add study update command with JSON template support
+
+### Collections
+
+- Add exclusive option field to multiple choice instructions
+- Extract shared exclusive options validation logic
+- Remove exclusive options validation from CLI
+
 ## 0.0.60
 
 - Maintenance and dependency updates


### PR DESCRIPTION
## Summary
- Generate release notes for v0.0.61 via `make changelog`
- Covers changes since v0.0.60: study update command, exclusive options for collections