### PR TITLE
feat(DCP-2517): add submission request-return command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,7 @@ type API interface {
 	GetStudies(status, projectID string) (*ListStudiesResponse, error)
 	GetStudy(ID string) (*model.Study, error)
 	GetSubmissions(ID string, limit, offset int) (*ListSubmissionsResponse, error)
+	RequestSubmissionReturn(ID string, reasons []string) (*RequestSubmissionReturnResponse, error)
 	TransitionStudy(ID, action string) (*TransitionStudyResponse, error)
 	UpdateStudy(ID string, study any) (*model.Study, error)
 	GetStudyCredentialsUsageReportCSV(ID string) (string, error)
@@ -304,6 +305,23 @@ func (c *Client) GetSubmissions(ID string, limit, offset int) (*ListSubmissionsR
 	_, err := c.Execute(http.MethodGet, url, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	return &response, nil
+}
+
+// RequestSubmissionReturn requests a participant to return a submission.
+func (c *Client) RequestSubmissionReturn(ID string, reasons []string) (*RequestSubmissionReturnResponse, error) {
+	var response RequestSubmissionReturnResponse
+
+	payload := RequestSubmissionReturnPayload{
+		Reasons: reasons,
+	}
+
+	url := fmt.Sprintf("/api/v1/submissions/%s/request-return/", ID)
+	_, err := c.Execute(http.MethodPost, url, payload, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to request submission return: %s", err)
 	}
 
 	return &response, nil

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -23,6 +23,11 @@ type SendGroupMessagePayload struct {
 	StudyID            string `json:"study_id,omitempty"`
 }
 
+// RequestSubmissionReturnPayload represents the JSON payload for requesting a submission return.
+type RequestSubmissionReturnPayload struct {
+	Reasons []string `json:"request_return_reasons"`
+}
+
 // CreateAITaskBuilderDatasetPayload represents the request for creating a dataset
 type CreateAITaskBuilderDatasetPayload struct {
 	Name        string `json:"name"`

--- a/client/responses.go
+++ b/client/responses.go
@@ -90,6 +90,14 @@ type ListFiltersResponse struct {
 	*JSONAPIMeta
 }
 
+// RequestSubmissionReturnResponse is the response for requesting a submission return.
+type RequestSubmissionReturnResponse struct {
+	ID              string  `json:"id"`
+	Status          string  `json:"status"`
+	Participant     string  `json:"participant"`
+	ReturnRequested *string `json:"return_requested"`
+}
+
 // TransitionStudyResponse is the response for transitioning a study to another status.
 type TransitionStudyResponse struct {
 	ID                      string   `json:"id"`

--- a/cmd/submission/request_return.go
+++ b/cmd/submission/request_return.go
@@ -1,0 +1,80 @@
+package submission
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+// RequestReturnOptions is the options for the request return command.
+type RequestReturnOptions struct {
+	SubmissionID string
+	Reasons      []string
+}
+
+// NewRequestReturnCommand creates a new `submission request-return` command to request
+// a participant to return a submission.
+func NewRequestReturnCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts RequestReturnOptions
+
+	cmd := &cobra.Command{
+		Use:   "request-return",
+		Short: "Request a participant to return a submission",
+		Long: `Request a participant to return a submission.
+
+This is an experimental feature that allows researchers to ask a participant to
+return a submission. The return reason must be provided and can be any free text.
+
+Common reasons include:
+  - Didn't finish the study
+  - Encountered technical problems
+  - Withdrew consent`,
+		Example: `  prolific submission request-return <submission-id> -r "Didn't finish the study"
+  prolific submission request-return <submission-id> -r "Encountered technical problems" -r "Withdrew consent"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.SubmissionID = args[0]
+
+			err := requestReturn(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringArrayVarP(&opts.Reasons, "reason", "r", nil, "Reason for requesting return (can be specified multiple times)")
+	_ = cmd.MarkFlagRequired("reason")
+
+	return cmd
+}
+
+func requestReturn(client client.API, opts RequestReturnOptions, w io.Writer) error {
+	response, err := client.RequestSubmissionReturn(opts.SubmissionID, opts.Reasons)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 1, 1, ' ', 0)
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "ID", "Status", "Participant", "Return Requested")
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+		response.ID,
+		response.Status,
+		response.Participant,
+		formatReturnRequested(response.ReturnRequested),
+	)
+
+	return tw.Flush()
+}
+
+func formatReturnRequested(t *string) string {
+	if t == nil {
+		return "-"
+	}
+	return *t
+}

--- a/cmd/submission/request_return_test.go
+++ b/cmd/submission/request_return_test.go
@@ -1,0 +1,195 @@
+package submission_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/submission"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+const testSubmissionID = "sub-123"
+
+func TestNewRequestReturnCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := submission.NewRequestReturnCommand(c, os.Stdout)
+
+	use := "request-return"
+	short := "Request a participant to return a submission"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestRequestReturnCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	returnTime := "2026-03-11T10:00:00Z"
+
+	response := client.RequestSubmissionReturnResponse{
+		ID:              testSubmissionID,
+		Status:          "ACTIVE",
+		Participant:     "participant-456",
+		ReturnRequested: &returnTime,
+	}
+
+	c.
+		EXPECT().
+		RequestSubmissionReturn(
+			gomock.Eq(testSubmissionID),
+			gomock.Eq([]string{"Didn't finish the study"}),
+		).
+		Return(&response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewRequestReturnCommand(c, writer)
+	_ = cmd.Flags().Set("reason", "Didn't finish the study")
+	_ = cmd.RunE(cmd, []string{testSubmissionID})
+	writer.Flush()
+
+	expected := "ID      Status Participant     Return Requested\nsub-123 ACTIVE participant-456 2026-03-11T10:00:00Z\n"
+	actual := b.String()
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'", expected, actual)
+	}
+}
+
+func TestRequestReturnCommandHandlesAPIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		RequestSubmissionReturn(
+			gomock.Eq(testSubmissionID),
+			gomock.Eq([]string{"Withdrew consent"}),
+		).
+		Return(nil, errors.New("submission not found"))
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewRequestReturnCommand(c, writer)
+	_ = cmd.Flags().Set("reason", "Withdrew consent")
+	err := cmd.RunE(cmd, []string{testSubmissionID})
+	writer.Flush()
+
+	expected := "error: submission not found"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected error '%s', got '%v'", expected, err)
+	}
+}
+
+func TestRequestReturnCommandRequiresReason(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewRequestReturnCommand(c, writer)
+	cmd.SetArgs([]string{testSubmissionID})
+	err := cmd.Execute()
+
+	writer.Flush()
+
+	if err == nil {
+		t.Fatal("expected error when reason flag is missing")
+	}
+}
+
+func TestRequestReturnCommandWithNilReturnRequested(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := client.RequestSubmissionReturnResponse{
+		ID:              testSubmissionID,
+		Status:          "ACTIVE",
+		Participant:     "participant-456",
+		ReturnRequested: nil,
+	}
+
+	c.
+		EXPECT().
+		RequestSubmissionReturn(
+			gomock.Eq(testSubmissionID),
+			gomock.Eq([]string{"Didn't finish the study"}),
+		).
+		Return(&response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewRequestReturnCommand(c, writer)
+	_ = cmd.Flags().Set("reason", "Didn't finish the study")
+	_ = cmd.RunE(cmd, []string{testSubmissionID})
+	writer.Flush()
+
+	expected := "ID      Status Participant     Return Requested\nsub-123 ACTIVE participant-456 -\n"
+	actual := b.String()
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'", expected, actual)
+	}
+}
+
+func TestRequestReturnCommandWithMultipleReasons(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	submissionID := "sub-789"
+	returnTime := "2026-03-11T12:00:00Z"
+
+	response := client.RequestSubmissionReturnResponse{
+		ID:              submissionID,
+		Status:          "ACTIVE",
+		Participant:     "participant-101",
+		ReturnRequested: &returnTime,
+	}
+
+	c.
+		EXPECT().
+		RequestSubmissionReturn(
+			gomock.Eq(submissionID),
+			gomock.Eq([]string{"Didn't finish the study", "Encountered technical problems"}),
+		).
+		Return(&response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewRequestReturnCommand(c, writer)
+	_ = cmd.Flags().Set("reason", "Didn't finish the study")
+	_ = cmd.Flags().Set("reason", "Encountered technical problems")
+	_ = cmd.RunE(cmd, []string{submissionID})
+	writer.Flush()
+
+	expected := "ID      Status Participant     Return Requested\nsub-789 ACTIVE participant-101 2026-03-11T12:00:00Z\n"
+	actual := b.String()
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'", expected, actual)
+	}
+}

--- a/cmd/submission/submission.go
+++ b/cmd/submission/submission.go
@@ -21,6 +21,7 @@ commands allow you to manage those submissions.
 
 	cmd.AddCommand(
 		NewListCommand(client, w),
+		NewRequestReturnCommand(client, w),
 	)
 	return cmd
 }

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -678,6 +678,21 @@ func (mr *MockAPIMockRecorder) PayBonusPayments(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PayBonusPayments", reflect.TypeOf((*MockAPI)(nil).PayBonusPayments), id)
 }
 
+// RequestSubmissionReturn mocks base method.
+func (m *MockAPI) RequestSubmissionReturn(ID string, reasons []string) (*client.RequestSubmissionReturnResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestSubmissionReturn", ID, reasons)
+	ret0, _ := ret[0].(*client.RequestSubmissionReturnResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestSubmissionReturn indicates an expected call of RequestSubmissionReturn.
+func (mr *MockAPIMockRecorder) RequestSubmissionReturn(ID, reasons interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSubmissionReturn", reflect.TypeOf((*MockAPI)(nil).RequestSubmissionReturn), ID, reasons)
+}
+
 // SendGroupMessage mocks base method.
 func (m *MockAPI) SendGroupMessage(participantGroupID, body string, studyID *string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Closes #303

## Summary
- Add `prolific submission request-return` command to request a participant to return a submission
- Supports multiple reasons via repeated `-r` flags (e.g. `-r "Didn't finish" -r "Technical problems"`)
- Calls `POST /api/v1/submissions/{id}/request-return/` with `request_return_reasons` payload
- Displays submission ID, status, participant, and return requested timestamp on success

## Usage
```bash
prolific submission request-return <submission-id> -r "Didn't finish the study"
prolific submission request-return <submission-id> -r "Encountered technical problems" -r "Withdrew consent"
```

## Test plan
- [x] Unit tests pass (`make test`) and linter passes (`make lint`)
- [x] Command succeeds against API on orange dev environment
  - [x] Single reason: returned timed-out submission successfully
  - [x] Multiple reasons: returned awaiting-review submission successfully
  - [x] No reason flag: `error: at least one reason is required`
  - [x] Invalid submission ID: API error returned
  - [x] No args: cobra arg validation error