### PR TITLE
feat(DCP-2527): add min/max validation for free_text and free_text_with_unit instructions

### DIFF
--- a/client/payloads.go
+++ b/client/payloads.go
@@ -83,10 +83,18 @@ type InstructionOption struct {
 	Exclusive bool   `json:"exclusive,omitempty"`
 }
 
+// ValidationRule represents min/max validation for free_text and free_text_with_unit instructions.
+type ValidationRule struct {
+	Type string   `json:"type"`
+	Min  *float64 `json:"min"`
+	Max  *float64 `json:"max"`
+}
+
 // UnitOption represents a unit option for free_text_with_unit instructions
 type UnitOption struct {
-	Label string `json:"label"`
-	Value string `json:"value"`
+	Label      string          `json:"label"`
+	Value      string          `json:"value"`
+	Validation *ValidationRule `json:"validation,omitempty"`
 }
 
 // Instruction represents a single instruction in the request payload
@@ -101,6 +109,7 @@ type Instruction struct {
 	UnitPosition         string              `json:"unit_position,omitempty"`
 	HelperText           string              `json:"helper_text,omitempty"`
 	PlaceholderTextInput string              `json:"placeholder_text_input,omitempty"`
+	Validation           *ValidationRule     `json:"validation,omitempty"`
 	AcceptedFileTypes    []string            `json:"accepted_file_types,omitempty"`
 	MaxFileSizeMB        *float64            `json:"max_file_size_mb,omitempty"`
 	MinFileCount         *int                `json:"min_file_count,omitempty"`

--- a/cmd/aitaskbuilder/batch_instructions_test.go
+++ b/cmd/aitaskbuilder/batch_instructions_test.go
@@ -951,3 +951,289 @@ func TestNewBatchInstructionsCommandExclusiveWithMultipleChoiceWithFreeText(t *t
 		t.Fatalf("expected output to contain '%s'; got %s", expectedOutput, buf.String())
 	}
 }
+
+func TestNewBatchInstructionsCommandFreeTextWithValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		batchID        string
+		instID         string
+		description    string
+		validationType string
+		min            *float64
+		max            *float64
+		jsonValidation string
+	}{
+		{
+			name:           "number validation",
+			batchID:        "01954894-65b3-779e-aaf6-348698e12360",
+			instID:         "inst-val-1",
+			description:    "Enter a score from 0 to 100.",
+			validationType: "number",
+			min:            func() *float64 { v := float64(0); return &v }(),
+			max:            func() *float64 { v := float64(100); return &v }(),
+			jsonValidation: `"validation": {"type": "number", "min": 0, "max": 100}`,
+		},
+		{
+			name:           "string validation",
+			batchID:        "01954894-65b3-779e-aaf6-348698e12361",
+			instID:         "inst-val-2",
+			description:    "Explain your reasoning.",
+			validationType: "string",
+			min:            func() *float64 { v := float64(10); return &v }(),
+			max:            func() *float64 { v := float64(500); return &v }(),
+			jsonValidation: `"validation": {"type": "string", "min": 10, "max": 500}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c := mock_client.NewMockAPI(ctrl)
+
+			response := client.CreateAITaskBuilderInstructionsResponse{
+				model.Instruction{
+					ID:          tt.instID,
+					Type:        "free_text",
+					BatchID:     tt.batchID,
+					CreatedBy:   "Sean",
+					CreatedAt:   "2024-09-18T07:50:15.055Z",
+					Description: tt.description,
+				},
+			}
+
+			instructions := client.CreateAITaskBuilderInstructionsPayload{
+				Instructions: []client.Instruction{
+					{
+						Type:        "free_text",
+						CreatedBy:   "Sean",
+						Description: tt.description,
+						Validation: &client.ValidationRule{
+							Type: tt.validationType,
+							Min:  tt.min,
+							Max:  tt.max,
+						},
+					},
+				},
+			}
+
+			c.EXPECT().CreateAITaskBuilderInstructions(tt.batchID, instructions).Return(&response, nil)
+
+			var buf bytes.Buffer
+			writer := bufio.NewWriter(&buf)
+
+			cmd := aitaskbuilder.NewBatchInstructionsCommand(c, writer)
+
+			instructionsJSON := `[{
+				"type": "free_text",
+				"created_by": "Sean",
+				"description": "` + tt.description + `",
+				` + tt.jsonValidation + `
+			}]`
+
+			cmd.SetArgs([]string{"-b", tt.batchID, "-j", instructionsJSON})
+
+			err := cmd.Execute()
+			if err != nil {
+				t.Fatalf("expected no error; got %s", err.Error())
+			}
+
+			writer.Flush()
+
+			if !strings.Contains(buf.String(), "Successfully added 1 instruction(s)") {
+				t.Fatalf("expected success message; got %s", buf.String())
+			}
+		})
+	}
+}
+
+func TestNewBatchInstructionsCommandFreeTextWithValidationTypeOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "01954894-65b3-779e-aaf6-348698e12362"
+
+	response := client.CreateAITaskBuilderInstructionsResponse{
+		model.Instruction{
+			ID:          "inst-val-3",
+			Type:        "free_text",
+			BatchID:     batchID,
+			CreatedBy:   "Sean",
+			CreatedAt:   "2024-09-18T07:50:15.055Z",
+			Description: "Enter any number.",
+		},
+	}
+
+	instructions := client.CreateAITaskBuilderInstructionsPayload{
+		Instructions: []client.Instruction{
+			{
+				Type:        "free_text",
+				CreatedBy:   "Sean",
+				Description: "Enter any number.",
+				Validation: &client.ValidationRule{
+					Type: "number",
+				},
+			},
+		},
+	}
+
+	c.EXPECT().CreateAITaskBuilderInstructions(batchID, instructions).Return(&response, nil)
+
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+
+	cmd := aitaskbuilder.NewBatchInstructionsCommand(c, writer)
+
+	instructionsJSON := `[{
+		"type": "free_text",
+		"created_by": "Sean",
+		"description": "Enter any number.",
+		"validation": {"type": "number"}
+	}]`
+
+	cmd.SetArgs([]string{"-b", batchID, "-j", instructionsJSON})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error; got %s", err.Error())
+	}
+
+	writer.Flush()
+
+	if !strings.Contains(buf.String(), "Successfully added 1 instruction(s)") {
+		t.Fatalf("expected success message; got %s", buf.String())
+	}
+}
+
+func TestNewBatchInstructionsCommandFreeTextWithUnitWithUnitOptionValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "01954894-65b3-779e-aaf6-348698e12367"
+
+	minKg := float64(20)
+	maxKg := float64(300)
+	minLbs := float64(44)
+	maxLbs := float64(660)
+
+	response := client.CreateAITaskBuilderInstructionsResponse{
+		model.Instruction{
+			ID:          "inst-val-unit-1",
+			Type:        "free_text_with_unit",
+			BatchID:     batchID,
+			CreatedBy:   "Sean",
+			CreatedAt:   "2024-09-18T07:50:15.055Z",
+			Description: "What is your weight?",
+			UnitOptions: []model.UnitOption{
+				{Label: "KG", Value: "kg"},
+				{Label: "Pounds", Value: "lbs"},
+			},
+			UnitPosition: model.UnitPositionSuffix,
+		},
+	}
+
+	instructions := client.CreateAITaskBuilderInstructionsPayload{
+		Instructions: []client.Instruction{
+			{
+				Type:        "free_text_with_unit",
+				CreatedBy:   "Sean",
+				Description: "What is your weight?",
+				UnitOptions: []client.UnitOption{
+					{Label: "KG", Value: "kg", Validation: &client.ValidationRule{Type: "number", Min: &minKg, Max: &maxKg}},
+					{Label: "Pounds", Value: "lbs", Validation: &client.ValidationRule{Type: "number", Min: &minLbs, Max: &maxLbs}},
+				},
+				UnitPosition: string(model.UnitPositionSuffix),
+			},
+		},
+	}
+
+	c.EXPECT().CreateAITaskBuilderInstructions(batchID, instructions).Return(&response, nil)
+
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+
+	cmd := aitaskbuilder.NewBatchInstructionsCommand(c, writer)
+
+	instructionsJSON := `[{
+		"type": "free_text_with_unit",
+		"created_by": "Sean",
+		"description": "What is your weight?",
+		"unit_options": [
+			{"label": "KG", "value": "kg", "validation": {"type": "number", "min": 20, "max": 300}},
+			{"label": "Pounds", "value": "lbs", "validation": {"type": "number", "min": 44, "max": 660}}
+		],
+		"unit_position": "suffix"
+	}]`
+
+	cmd.SetArgs([]string{"-b", batchID, "-j", instructionsJSON})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error; got %s", err.Error())
+	}
+
+	writer.Flush()
+
+	if !strings.Contains(buf.String(), "Successfully added 1 instruction(s)") {
+		t.Fatalf("expected success message; got %s", buf.String())
+	}
+}
+
+func TestNewBatchInstructionsCommandFreeTextWithExplicitNullValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := "01954894-65b3-779e-aaf6-348698e12369"
+
+	response := client.CreateAITaskBuilderInstructionsResponse{
+		model.Instruction{
+			ID:          "inst-val-null",
+			Type:        "free_text",
+			BatchID:     batchID,
+			CreatedBy:   "Sean",
+			CreatedAt:   "2024-09-18T07:50:15.055Z",
+			Description: "Enter a value.",
+		},
+	}
+
+	instructions := client.CreateAITaskBuilderInstructionsPayload{
+		Instructions: []client.Instruction{
+			{
+				Type:        "free_text",
+				CreatedBy:   "Sean",
+				Description: "Enter a value.",
+			},
+		},
+	}
+
+	c.EXPECT().CreateAITaskBuilderInstructions(batchID, instructions).Return(&response, nil)
+
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+
+	cmd := aitaskbuilder.NewBatchInstructionsCommand(c, writer)
+
+	// Explicit null should be treated as absent (no validation)
+	instructionsJSON := `[{
+		"type": "free_text",
+		"created_by": "Sean",
+		"description": "Enter a value.",
+		"validation": null
+	}]`
+
+	cmd.SetArgs([]string{"-b", batchID, "-j", instructionsJSON})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error; got %s", err.Error())
+	}
+
+	writer.Flush()
+
+	if !strings.Contains(buf.String(), "Successfully added 1 instruction(s)") {
+		t.Fatalf("expected success message; got %s", buf.String())
+	}
+}

--- a/docs/examples/batch-instructions.json
+++ b/docs/examples/batch-instructions.json
@@ -3,7 +3,12 @@
     "type": "free_text",
     "created_by": "Sean",
     "description": "Please explain your reasoning for the choice you made above.",
-    "placeholder_text_input": "Enter your explanation here..."
+    "placeholder_text_input": "Enter your explanation here...",
+    "validation": {
+      "type": "string",
+      "min": 10,
+      "max": 500
+    }
   },
   {
     "type": "multiple_choice",
@@ -82,11 +87,13 @@
     "unit_options": [
       {
         "label": "°C",
-        "value": "celsius"
+        "value": "celsius",
+        "validation": { "type": "number", "min": 30, "max": 45 }
       },
       {
         "label": "°F",
-        "value": "fahrenheit"
+        "value": "fahrenheit",
+        "validation": { "type": "number", "min": 86, "max": 113 }
       }
     ],
     "default_unit": "celsius",

--- a/docs/examples/collection.json
+++ b/docs/examples/collection.json
@@ -19,7 +19,12 @@
         {
           "order": 1,
           "type": "free_text",
-          "description": "How was your experience completing this task?"
+          "description": "How was your experience completing this task?",
+          "validation": {
+            "type": "string",
+            "min": 10,
+            "max": 500
+          }
         },
         {
           "order": 2,
@@ -46,11 +51,13 @@
           "unit_options": [
             {
               "label": "KG",
-              "value": "kg"
+              "value": "kg",
+              "validation": { "type": "number", "min": 20, "max": 300 }
             },
             {
               "label": "Pounds",
-              "value": "lbs"
+              "value": "lbs",
+              "validation": { "type": "number", "min": 44, "max": 660 }
             }
           ],
           "default_unit": "kg",

--- a/model/ai_task_builder.go
+++ b/model/ai_task_builder.go
@@ -89,6 +89,7 @@ type Instruction struct {
 	UnitPosition         UnitPosition        `json:"unit_position,omitempty"`
 	HelperText           string              `json:"helper_text,omitempty"`
 	PlaceholderTextInput string              `json:"placeholder_text_input,omitempty"`
+	Validation           *ValidationRule     `json:"validation,omitempty"`
 	AcceptedFileTypes    []string            `json:"accepted_file_types,omitempty"`
 	MaxFileSizeMB        *float64            `json:"max_file_size_mb,omitempty"`
 	MinFileCount         *int                `json:"min_file_count,omitempty"`
@@ -192,6 +193,7 @@ type CollectionPageItem struct {
 	PlaceholderTextInput string              `json:"placeholder_text_input,omitempty" mapstructure:"placeholder_text_input"`
 	DisableDropdown      *bool               `json:"disable_dropdown,omitempty" mapstructure:"disable_dropdown"`
 	HelperText           string              `json:"helper_text,omitempty" mapstructure:"helper_text"`
+	Validation           *ValidationRule     `json:"validation,omitempty" mapstructure:"validation"`
 
 	// Unit fields (for free_text_with_unit)
 	UnitOptions  []UnitOption `json:"unit_options,omitempty" mapstructure:"unit_options"`

--- a/model/collection.go
+++ b/model/collection.go
@@ -70,10 +70,18 @@ type MultipleChoiceOption struct {
 	Exclusive bool   `json:"exclusive,omitempty" yaml:"exclusive,omitempty" mapstructure:"exclusive"`
 }
 
+// ValidationRule represents min/max validation for free_text and free_text_with_unit instructions.
+type ValidationRule struct {
+	Type string   `json:"type" yaml:"type" mapstructure:"type"`
+	Min  *float64 `json:"min" yaml:"min" mapstructure:"min"`
+	Max  *float64 `json:"max" yaml:"max" mapstructure:"max"`
+}
+
 // UnitOption represents a unit option for free_text_with_unit instructions
 type UnitOption struct {
-	Label string `json:"label" yaml:"label" mapstructure:"label"`
-	Value string `json:"value" yaml:"value" mapstructure:"value"`
+	Label      string          `json:"label" yaml:"label" mapstructure:"label"`
+	Value      string          `json:"value" yaml:"value" mapstructure:"value"`
+	Validation *ValidationRule `json:"validation,omitempty" yaml:"validation,omitempty" mapstructure:"validation"`
 }
 
 // PageInstruction represents a single page item within a collection page.
@@ -89,8 +97,9 @@ type PageInstruction struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description"`
 
 	// Optional - for free_text and free_text_with_unit types
-	PlaceholderTextInput string `json:"placeholder_text_input,omitempty" yaml:"placeholder_text_input,omitempty" mapstructure:"placeholder_text_input"`
-	HelperText           string `json:"helper_text,omitempty" yaml:"helper_text,omitempty" mapstructure:"helper_text"`
+	PlaceholderTextInput string          `json:"placeholder_text_input,omitempty" yaml:"placeholder_text_input,omitempty" mapstructure:"placeholder_text_input"`
+	HelperText           string          `json:"helper_text,omitempty" yaml:"helper_text,omitempty" mapstructure:"helper_text"`
+	Validation           *ValidationRule `json:"validation,omitempty" yaml:"validation,omitempty" mapstructure:"validation"`
 
 	// Optional - for multiple_choice and multiple_choice_with_free_text types
 	AnswerLimit     int                    `json:"answer_limit,omitempty" yaml:"answer_limit,omitempty" mapstructure:"answer_limit"`


### PR DESCRIPTION
## Summary

Adds optional `validation` field support for `free_text` and `free_text_with_unit` instruction types, enabling min/max bounds on user input. Validation logic is deferred to the backend — the CLI passes the field through and surfaces API errors directly.

## Validation Schema

```json
{
  "type": "number" | "string",
  "min": number | null,
  "max": number | null
}
```

- **`free_text`**: `validation` is a top-level field on the instruction
- **`free_text_with_unit`**: `validation` is per-`unit_option` (each unit can have different bounds)
- `type` is required; `min`/`max` are nullable (`null` = unbounded in that direction)

### Usage Examples

Collection JSON with `free_text` string validation (character count bounds):

```json
{
  "order": 1,
  "type": "free_text",
  "description": "How was your experience completing this task?",
  "validation": {
    "type": "string",
    "min": 10,
    "max": 500
  }
}
```

Collection JSON with `free_text_with_unit` per-unit number validation:

```json
{
  "order": 3,
  "type": "free_text_with_unit",
  "description": "What is your current weight?",
  "unit_options": [
    {
      "label": "KG",
      "value": "kg",
      "validation": { "type": "number", "min": 20, "max": 300 }
    },
    {
      "label": "Pounds",
      "value": "lbs",
      "validation": { "type": "number", "min": 44, "max": 660 }
    }
  ],
  "default_unit": "kg",
  "unit_position": "suffix"
}
```

## Implementation

- Added `ValidationRule` struct to `model/collection.go` and `client/payloads.go`
- Added `Validation` field to `Instruction`, `UnitOption`, `PageInstruction`, and `CollectionPageItem` structs
- `Min`/`Max` use `*float64` without `omitempty` — backend requires explicit `null` (not field absence) for unbounded values
- No CLI-side validation — backend is the single source of truth for validation rules
- Updated example files with validation usage

## Testing

Unit tests:
- Passthrough tests for number and string validation on `free_text` instructions
- Passthrough test for `free_text_with_unit` with per-unit-option validation
- Validation with only `type` specified (no min/max)
- Explicit `null` validation handled correctly

Manually verified against dev:
- `free_text` with string validation (min/max char count) — created successfully
- `free_text_with_unit` with per-unit number validation — created successfully
- Unbounded max (`null`) — created successfully
- Invalid validation type — backend error surfaced correctly
- min > max — backend error surfaced correctly
- DynamoDB records confirmed all validation fields persisted correctly