### PR TITLE
feat: provide `-n | --non-interactive` option for the `filters` command

### DIFF
--- a/cmd/filters/list.go
+++ b/cmd/filters/list.go
@@ -3,15 +3,25 @@ package filters
 import (
 	"fmt"
 	"io"
+	"text/tabwriter"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/ui"
 	"github.com/prolific-oss/cli/ui/filter"
 	"github.com/spf13/cobra"
 )
 
+// ListOptions are the options for the list filters command.
+type ListOptions struct {
+	Args           []string
+	NonInteractive bool
+}
+
 func NewListCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts ListOptions
+
 	cmd := &cobra.Command{
 		Use:   "filters",
 		Short: "List all filters available for your study",
@@ -30,7 +40,15 @@ There are two types of filters:
   a given participant attribute.`,
 		Example: ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := renderList(client)
+			opts.Args = args
+
+			var err error
+			if opts.NonInteractive {
+				err = renderNonInteractive(client, w)
+			} else {
+				err = renderInteractive(client)
+			}
+
 			if err != nil {
 				return fmt.Errorf("error: %s", err.Error())
 			}
@@ -39,10 +57,13 @@ There are two types of filters:
 		},
 	}
 
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.NonInteractive, "non-interactive", "n", false, "Render the list details straight to the terminal.")
+
 	return cmd
 }
 
-func renderList(client client.API) error {
+func renderInteractive(client client.API) error {
 	filters, err := client.GetFilters()
 	if err != nil {
 		return err
@@ -66,4 +87,50 @@ func renderList(client client.API) error {
 	}
 
 	return nil
+}
+
+func renderNonInteractive(client client.API, w io.Writer) error {
+	filters, err := client.GetFilters()
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 1, 1, ' ', 0)
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "Title", "FilterID", "Type", "DataType")
+
+	for _, f := range filters.Results {
+		dataType := formatDataType(f.DataType, f.Min, f.Max)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", f.Title(), f.FilterID, f.Type, dataType)
+	}
+
+	_ = tw.Flush()
+
+	total := len(filters.Results)
+	if filters.JSONAPIMeta != nil {
+		total = filters.JSONAPIMeta.Meta.Count
+	}
+	fmt.Fprintf(w, "\n%s\n", ui.RenderRecordCounter(len(filters.Results), total))
+
+	return nil
+}
+
+// formatDataType returns the data type string, appending range bounds in
+// parentheses when present, e.g. "integer (18–100)", "integer (min: 18)".
+func formatDataType(dataType string, min, max any) string {
+	hasMin := min != nil
+	hasMax := max != nil
+
+	if hasMin && hasMax {
+		return fmt.Sprintf("%s (%v\u2013%v)", dataType, min, max)
+	}
+
+	if hasMin {
+		return fmt.Sprintf("%s (min: %v)", dataType, min)
+	}
+
+	if hasMax {
+		return fmt.Sprintf("%s (max: %v)", dataType, max)
+	}
+
+	return dataType
 }

--- a/cmd/filters/list_test.go
+++ b/cmd/filters/list_test.go
@@ -1,1 +1,199 @@
 package filters_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/filters"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewListCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := filters.NewListCommand(c, os.Stdout)
+
+	use := "filters"
+	short := "List all filters available for your study"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewListCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := client.ListFiltersResponse{
+		Results: []model.Filter{
+			{
+				FilterID:    "age",
+				FilterTitle: "Age",
+				Type:        "range",
+				DataType:    "integer",
+				Min:         18,
+				Max:         100,
+			},
+			{
+				FilterID:    "handedness",
+				FilterTitle: "Handedness",
+				Type:        "select",
+				DataType:    "string",
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		GetFilters().
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := filters.NewListCommand(c, writer)
+	_ = cmd.Flags().Set("non-interactive", "true")
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	actual := b.String()
+
+	for _, expected := range []string{
+		"Title",
+		"FilterID",
+		"Type",
+		"DataType",
+		"Age",
+		"age",
+		"range",
+		"integer (18\u2013100)",
+		"Handedness",
+		"handedness",
+		"select",
+		"string",
+	} {
+		if !strings.Contains(actual, expected) {
+			t.Fatalf("expected output to contain %q, got:\n%s", expected, actual)
+		}
+	}
+}
+
+func TestNewListCommandCallsAPIWithMinOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := client.ListFiltersResponse{
+		Results: []model.Filter{
+			{
+				FilterID:    "score",
+				FilterTitle: "Score",
+				Type:        "range",
+				DataType:    "integer",
+				Min:         5,
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		GetFilters().
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := filters.NewListCommand(c, writer)
+	_ = cmd.Flags().Set("non-interactive", "true")
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	actual := b.String()
+	if !strings.Contains(actual, "integer (min: 5)") {
+		t.Fatalf("expected output to contain 'integer (min: 5)', got:\n%s", actual)
+	}
+}
+
+func TestNewListCommandCallsAPIWithMaxOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := client.ListFiltersResponse{
+		Results: []model.Filter{
+			{
+				FilterID:    "score",
+				FilterTitle: "Score",
+				Type:        "range",
+				DataType:    "integer",
+				Max:         100,
+			},
+		},
+	}
+
+	c.
+		EXPECT().
+		GetFilters().
+		Return(&response, nil).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := filters.NewListCommand(c, writer)
+	_ = cmd.Flags().Set("non-interactive", "true")
+	_ = cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	actual := b.String()
+	if !strings.Contains(actual, "integer (max: 100)") {
+		t.Fatalf("expected output to contain 'integer (max: 100)', got:\n%s", actual)
+	}
+}
+
+func TestNewListCommandHandlesAnAPIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	errorMessage := "something went wrong"
+
+	c.
+		EXPECT().
+		GetFilters().
+		Return(nil, errors.New(errorMessage)).
+		AnyTimes()
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := filters.NewListCommand(c, writer)
+	_ = cmd.Flags().Set("non-interactive", "true")
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}


### PR DESCRIPTION
This is mainly for AI agent use, and to make the commands consistent in
the way they work

<img width="1242" height="616" alt="Screenshot 2026-03-27 at 11 19 43" src="https://github.com/user-attachments/assets/8a4bc74d-65ec-4ef1-bc76-5b81d67243ef" />
