### PR TITLE
chore: do not os.exit on error for study file unmarshal

### DIFF
--- a/cmd/study/create.go
+++ b/cmd/study/create.go
@@ -3,7 +3,6 @@ package study
 import (
 	"fmt"
 	"io"
-	"log"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/prolific-oss/cli/model"
@@ -137,7 +136,7 @@ func createStudy(client client.API, opts CreateOptions, w io.Writer) error {
 	var s model.CreateStudy
 	err = v.Unmarshal(&s)
 	if err != nil {
-		log.Fatalf("unable to map %s to study model: %s", opts.TemplatePath, err)
+		return fmt.Errorf("unable to map %s to study model: %s", opts.TemplatePath, err)
 	}
 
 	study, err := client.CreateStudy(s)

--- a/cmd/study/create_test.go
+++ b/cmd/study/create_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -99,6 +100,42 @@ func TestCreateCommandHandlesFailureToReadConfig(t *testing.T) {
 	expected := "error: open broken-path.json: no such file or directory"
 	if err.Error() != expected {
 		t.Fatalf("expected %s, got %s", expected, err.Error())
+	}
+}
+
+func TestCreateCommandHandlesFailureToUnmarshalConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	// reward must be float64; a mapping causes Unmarshal to fail
+	if _, err = f.WriteString("reward:\n  not: a number\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := study.NewCreateCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+
+	err = cmd.RunE(cmd, nil)
+	writer.Flush()
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "'reward' expected type 'float64'") {
+		t.Fatalf("unexpected error: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
We want to return the error, so the framework can handle rendering the error to the user