### PR TITLE
fix: handle unknown currency code in RenderMoney without panic

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -39,8 +39,11 @@ func RenderMoney(amount float64, currencyCode string) string {
 		currencyCode = model.DefaultCurrency
 	}
 
+	cur, err := currency.ParseISO(currencyCode)
+	if err != nil {
+		return fmt.Sprintf("%.2f", amount)
+	}
 	p := message.NewPrinter(language.English)
-	cur := currency.MustParseISO(currencyCode)
 	return fmt.Sprintf("%s%.2f", p.Sprint(currency.Symbol(cur)), amount)
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -29,6 +29,11 @@ func TestRenderMoney(t *testing.T) {
 		amount:   80001.01,
 		currency: "USD",
 		expected: "$80001.01",
+	}, {
+		name:     "Unknown currency code falls back to raw amount",
+		amount:   5.00,
+		currency: "ZZZ",
+		expected: "5.00",
 	}}
 
 	for _, tc := range tt {


### PR DESCRIPTION
## Summary

`currency.MustParseISO` in `ui/ui.go` panics if the API returns a currency code the `golang.org/x/text/currency` library doesn't recognise, turning an API oddity into a hard crash with no user-facing error message. All callers that render money (bonus create/pay, study list, study view) were affected.

## Changes

- Replace `currency.MustParseISO(code)` with `currency.ParseISO(code)` in `RenderMoney`
- On parse error, fall back to rendering the raw numeric amount (e.g. `5.00`) without a currency symbol
- Add a test case for the unknown currency code fallback path