### PR TITLE
chore: update changelog for v0.0.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 0.0.65
+
+### Filters
+
+- Add non-interactive mode to filters command
+- Split renderList into interactive and non-interactive functions
+
+### Core
+
+- Add missing fields to study and filter models
+- Align weightings keys with selected_values in example
+- Handle unknown currency code in RenderMoney without panic
+- Remove the `requirements` command which is no longer supported
+
 ## 0.0.64
 
 ### Collections


### PR DESCRIPTION
## Summary
- Generate changelog for v0.0.65 release
- Manually add entries missed by the transform script (files in `ui/` and `docs/examples/` have no area mapping)

### Changelog entries for v0.0.65

**Filters**
- Add non-interactive mode to filters command
- Split renderList into interactive and non-interactive functions

**Core**
- Add missing fields to study and filter models
- Align weightings keys with selected_values in example
- Handle unknown currency code in RenderMoney without panic
- Remove the `requirements` command which is no longer supported