### PR TITLE
feat(DCP-2633): add template list and view commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prolific-oss/cli/cmd/project"
 	"github.com/prolific-oss/cli/cmd/study"
 	"github.com/prolific-oss/cli/cmd/submission"
+	"github.com/prolific-oss/cli/cmd/template"
 	"github.com/prolific-oss/cli/cmd/user"
 	"github.com/prolific-oss/cli/cmd/workspace"
 	"github.com/prolific-oss/cli/version"
@@ -82,6 +83,7 @@ func NewRootCommand() *cobra.Command {
 		study.NewListCommand("studies", &client, w),
 		study.NewStudyCommand(&client, w),
 		submission.NewSubmissionCommand(&client, w),
+		template.NewTemplateCommand(w),
 		user.NewMeCommand(&client, w),
 		workspace.NewWorkspaceCommand(&client, w),
 	)

--- a/cmd/template/list.go
+++ b/cmd/template/list.go
@@ -1,0 +1,112 @@
+package template
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/prolific-oss/cli/docs/examples"
+	"github.com/spf13/cobra"
+)
+
+// Template holds metadata about an embedded template file.
+type Template struct {
+	ID       string
+	Filename string
+	Category string
+	Format   string
+}
+
+// listTemplates returns all available study and collection templates from the
+// embedded filesystem.
+func listTemplates() []Template {
+	var templates []Template
+
+	_ = fs.WalkDir(examples.FS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext != ".json" && ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		name := strings.TrimSuffix(path, ext)
+
+		category := categorise(name)
+		if category == "" {
+			return nil
+		}
+
+		format := strings.TrimPrefix(ext, ".")
+		if format == "yml" {
+			format = "yaml"
+		}
+
+		templates = append(templates, Template{
+			ID:       name,
+			Filename: path,
+			Category: category,
+			Format:   format,
+		})
+
+		return nil
+	})
+
+	sort.Slice(templates, func(i, j int) bool {
+		if templates[i].Category != templates[j].Category {
+			return templates[i].Category < templates[j].Category
+		}
+		return templates[i].ID < templates[j].ID
+	})
+
+	return templates
+}
+
+// categorise returns the category for a template based on its filename, or
+// empty string if the file should be excluded.
+func categorise(name string) string {
+	if strings.HasPrefix(name, "collection") {
+		return "collection"
+	}
+	if strings.HasPrefix(name, "study-") ||
+		strings.HasPrefix(name, "standard-sample") ||
+		strings.HasPrefix(name, "minimal-study") ||
+		strings.HasPrefix(name, "multi-submission") ||
+		strings.HasPrefix(name, "multiple-participant") ||
+		strings.HasPrefix(name, "star-") {
+		return "study"
+	}
+	return ""
+}
+
+// NewListCommand creates the `template list` subcommand.
+func NewListCommand(w io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all available templates",
+		Long:  `List all bundled study and collection templates with their ID, category, and format.`,
+		Example: `
+List all templates
+$ prolific template list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			templates := listTemplates()
+
+			tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "ID\tCategory\tFormat")
+
+			for _, t := range templates {
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", t.ID, t.Category, t.Format)
+			}
+
+			return tw.Flush()
+		},
+	}
+
+	return cmd
+}

--- a/cmd/template/list_test.go
+++ b/cmd/template/list_test.go
@@ -1,0 +1,79 @@
+package template
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListTemplates(t *testing.T) {
+	templates := listTemplates()
+
+	assert.NotEmpty(t, templates)
+
+	ids := make(map[string]bool)
+	for _, tmpl := range templates {
+		ids[tmpl.ID+"."+tmpl.Format] = true
+		assert.NotEmpty(t, tmpl.ID)
+		assert.NotEmpty(t, tmpl.Filename)
+		assert.NotEmpty(t, tmpl.Category)
+		assert.Contains(t, []string{"study", "collection"}, tmpl.Category)
+		assert.Contains(t, []string{"json", "yaml"}, tmpl.Format)
+	}
+
+	assert.True(t, ids["standard-sample.json"])
+	assert.True(t, ids["collection.json"])
+	assert.True(t, ids["collection.yaml"])
+}
+
+func TestListTemplatesExcludesBatchInstructions(t *testing.T) {
+	templates := listTemplates()
+
+	for _, tmpl := range templates {
+		assert.NotEqual(t, "batch-instructions", tmpl.ID)
+	}
+}
+
+func TestListCommand(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewListCommand(&b)
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+
+	output := b.String()
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "Category")
+	assert.Contains(t, output, "Format")
+	assert.Contains(t, output, "standard-sample")
+	assert.Contains(t, output, "collection")
+	assert.Contains(t, output, "study")
+}
+
+func TestCategorise(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"standard-sample", "study"},
+		{"standard-sample-aitaskbuilder", "study"},
+		{"minimal-study", "study"},
+		{"multi-submission-study", "study"},
+		{"multiple-participant-groups-either-or", "study"},
+		{"study-with-filters", "study"},
+		{"star-trek", "study"},
+		{"star-wars", "study"},
+		{"collection", "collection"},
+		{"batch-instructions", ""},
+		{"aitb-model-evaluation", ""},
+		{"credentials", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, categorise(tt.name))
+		})
+	}
+}

--- a/cmd/template/template.go
+++ b/cmd/template/template.go
@@ -1,0 +1,25 @@
+package template
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// NewTemplateCommand creates the parent `template` command with subcommands.
+func NewTemplateCommand(w io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Browse and retrieve study and collection templates",
+		Long: `Templates are bundled example files that demonstrate how to create studies
+and collections via the CLI. Use these as starting points for your own
+configurations.`,
+	}
+
+	cmd.AddCommand(
+		NewListCommand(w),
+		NewViewCommand(w),
+	)
+
+	return cmd
+}

--- a/cmd/template/view.go
+++ b/cmd/template/view.go
@@ -1,0 +1,66 @@
+package template
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/docs/examples"
+	"github.com/spf13/cobra"
+)
+
+// NewViewCommand creates the `template <id>` subcommand.
+func NewViewCommand(w io.Writer) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "view <template-id>",
+		Short: "Display the contents of a template",
+		Long:  `Output the raw JSON or YAML content of a template by its ID.`,
+		Example: `
+View a template (defaults to JSON when both formats exist)
+$ prolific template view standard-sample
+
+View the YAML variant
+$ prolific template view standard-sample --format yaml
+
+Use the output to create a study
+$ prolific template view standard-sample > my-study.json
+$ prolific study create -t my-study.json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+
+			templates := listTemplates()
+
+			var match *Template
+			for i, t := range templates {
+				if t.ID != id {
+					continue
+				}
+				if format != "" && t.Format == format {
+					match = &templates[i]
+					break
+				}
+				if match == nil {
+					match = &templates[i]
+				}
+			}
+
+			if match == nil {
+				return fmt.Errorf("template %q not found, run 'prolific template list' to see available templates", id)
+			}
+
+			data, err := examples.FS.ReadFile(match.Filename)
+			if err != nil {
+				return fmt.Errorf("reading template %s: %w", id, err)
+			}
+			fmt.Fprint(w, string(data))
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&format, "format", "f", "", "Preferred format when both exist (json or yaml)")
+
+	return cmd
+}

--- a/cmd/template/view_test.go
+++ b/cmd/template/view_test.go
@@ -1,0 +1,80 @@
+package template
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestViewCommand(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewViewCommand(&b)
+	cmd.SetArgs([]string{"standard-sample"})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+
+	output := b.String()
+	assert.Contains(t, output, "My first standard sample")
+	assert.Contains(t, output, "external_study_url")
+	assert.Contains(t, output, "prolific_id_option")
+}
+
+func TestViewCommandCollection(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewViewCommand(&b)
+	cmd.SetArgs([]string{"collection"})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b.String())
+}
+
+func TestViewCommandNotFound(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewViewCommand(&b)
+	cmd.SetArgs([]string{"nonexistent"})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestViewCommandFormatYAML(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewViewCommand(&b)
+	cmd.SetArgs([]string{"standard-sample", "--format", "yaml"})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+
+	output := b.String()
+	assert.Contains(t, output, "name:")
+	assert.Contains(t, output, "device_compatibility:")
+	assert.NotContains(t, output, `"name":`)
+}
+
+func TestViewCommandDefaultsToJSON(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewViewCommand(&b)
+	cmd.SetArgs([]string{"standard-sample"})
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Contains(t, b.String(), "{")
+}
+
+func TestViewCommandNoArgs(t *testing.T) {
+	var b bytes.Buffer
+
+	cmd := NewViewCommand(&b)
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+}

--- a/docs/examples/examples.go
+++ b/docs/examples/examples.go
@@ -1,0 +1,7 @@
+// Package examples provides embedded study and collection template files.
+package examples
+
+import "embed"
+
+//go:embed *.json *.yaml
+var FS embed.FS


### PR DESCRIPTION
## Summary

Adds a new `prolific template` command that lets humans and AI agents browse and retrieve the bundled study and collection example files without needing the repo cloned.

### New commands

#### `prolific template list`

Lists all available templates in a non-interactive table format:

```
$ prolific template list
ID                                             Category    Format
collection                                     collection  json
collection                                     collection  yaml
minimal-study                                  study       json
standard-sample                                study       json
standard-sample                                study       yaml
study-with-weighted-filters                    study       json
...
```

#### `prolific template view <id>`

Outputs the raw JSON or YAML content of a template by its ID. Defaults to JSON when both formats exist.

```
$ prolific template view standard-sample
{
  "name": "My first standard sample",
  ...
}

$ prolific template view standard-sample --format yaml
name: My first standard sample
...
```

**Flags:**
- `-f` / `--format` — preferred format when both JSON and YAML exist (`json` or `yaml`)

#### Piping to study create

```bash
prolific template view standard-sample > my-study.json
prolific study create -t my-study.json
```

### How it works

- Templates are embedded into the binary at compile time using Go's `//go:embed` (~24KB added to ~13MB binary)
- No API client dependency — reads from embedded filesystem only
- No `PROLIFIC_TOKEN` required
- Works across all release targets (darwin, linux, windows, freebsd)
- Templates categorised by filename prefix into study or collection

### Known limitations

- The `//go:embed *.json *.yaml` glob also embeds `batch-instructions.json` (~3.2KB) which is excluded from listing but still in the binary. Trivial overhead, keeps the directive simple for auto-including new templates.

## Test plan

- [x] `make build`, `make test` (10 new tests, 87.8% coverage), `make lint` all pass
- [x] Manual: `template list`, `template view`, `--format yaml` all verified locally

Resolves [DCP-2633](https://prolific.atlassian.net/browse/DCP-2633)

[DCP-2633]: https://prolific.atlassian.net/browse/DCP-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ