### PR TITLE
chore: remove unused param for UpdateCredentialPool

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -41,7 +41,7 @@ type API interface {
 	UpdateStudy(ID string, study any) (*model.Study, error)
 	GetStudyCredentialsUsageReportCSV(ID string) (string, error)
 	CreateCredentialPool(credentials string, workspaceID string) (*CredentialPoolResponse, error)
-	UpdateCredentialPool(credentialPoolID string, credentials string, workspaceID string) (*CredentialPoolResponse, error)
+	UpdateCredentialPool(credentialPoolID string, credentials string) (*CredentialPoolResponse, error)
 	ListCredentialPools(workspaceID string) (*ListCredentialPoolsResponse, error)
 
 	GetCampaigns(workspaceID string, limit, offset int) (*ListCampaignsResponse, error)
@@ -1022,7 +1022,7 @@ func (c *Client) CreateCredentialPool(credentials string, workspaceID string) (*
 
 // UpdateCredentialPool updates an existing credential pool with new credentials.
 // credentials should be a comma-separated string with newlines between entries.
-func (c *Client) UpdateCredentialPool(credentialPoolID string, credentials string, workspaceID string) (*CredentialPoolResponse, error) {
+func (c *Client) UpdateCredentialPool(credentialPoolID string, credentials string) (*CredentialPoolResponse, error) {
 	var response CredentialPoolResponse
 
 	payload := UpdateCredentialPoolPayload{

--- a/cmd/credentials/update.go
+++ b/cmd/credentials/update.go
@@ -50,7 +50,7 @@ user3@example.com,p4ssw0rd3`,
 				return err
 			}
 
-			response, err := client.UpdateCredentialPool(credentialPoolID, credentials, "")
+			response, err := client.UpdateCredentialPool(credentialPoolID, credentials)
 			if err != nil {
 				return err
 			}

--- a/cmd/credentials/update_test.go
+++ b/cmd/credentials/update_test.go
@@ -99,7 +99,7 @@ Credential Pool ID: pool123456
 			// Only expect API call if we have enough args and credentials
 			if len(tt.args) > 1 {
 				c.EXPECT().
-					UpdateCredentialPool(tt.args[0], gomock.Any(), "").
+					UpdateCredentialPool(tt.args[0], gomock.Any()).
 					Return(tt.mockReturn, tt.mockError).
 					Times(1)
 			}
@@ -148,7 +148,7 @@ func TestUpdateCredentialPoolFromFile(t *testing.T) {
 	credFile := createTempCredentialsFile(t, credContent)
 
 	c.EXPECT().
-		UpdateCredentialPool(testCredPoolID, credContent, "").
+		UpdateCredentialPool(testCredPoolID, credContent).
 		Return(&client.CredentialPoolResponse{
 			CredentialPoolID: testCredPoolID,
 		}, nil).
@@ -182,7 +182,7 @@ func TestUpdateCredentialPoolFromFileWithTrailingNewline(t *testing.T) {
 	credFile := createTempCredentialsFile(t, testCredentials+"\n")
 
 	c.EXPECT().
-		UpdateCredentialPool(testCredPoolID, testCredentials, "").
+		UpdateCredentialPool(testCredPoolID, testCredentials).
 		Return(&client.CredentialPoolResponse{
 			CredentialPoolID: testCredPoolID,
 		}, nil).

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -782,18 +782,18 @@ func (mr *MockAPIMockRecorder) UpdateCollection(ID, collection interface{}) *gom
 }
 
 // UpdateCredentialPool mocks base method.
-func (m *MockAPI) UpdateCredentialPool(credentialPoolID, credentials, workspaceID string) (*client.CredentialPoolResponse, error) {
+func (m *MockAPI) UpdateCredentialPool(credentialPoolID, credentials string) (*client.CredentialPoolResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCredentialPool", credentialPoolID, credentials, workspaceID)
+	ret := m.ctrl.Call(m, "UpdateCredentialPool", credentialPoolID, credentials)
 	ret0, _ := ret[0].(*client.CredentialPoolResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateCredentialPool indicates an expected call of UpdateCredentialPool.
-func (mr *MockAPIMockRecorder) UpdateCredentialPool(credentialPoolID, credentials, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateCredentialPool(credentialPoolID, credentials interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCredentialPool", reflect.TypeOf((*MockAPI)(nil).UpdateCredentialPool), credentialPoolID, credentials, workspaceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCredentialPool", reflect.TypeOf((*MockAPI)(nil).UpdateCredentialPool), credentialPoolID, credentials)
 }
 
 // UpdateStudy mocks base method.


### PR DESCRIPTION
Workspace ID is not required or available on this endpoint. See docs https://docs.prolific.com/api-reference/credentials/update-credential-pool