### PR TITLE
feat(DCP-2516): add submission transition and bulk-approve commands

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,8 @@ type API interface {
 	GetStudy(ID string) (*model.Study, error)
 	GetSubmissions(ID string, limit, offset int) (*ListSubmissionsResponse, error)
 	RequestSubmissionReturn(ID string, reasons []string) (*RequestSubmissionReturnResponse, error)
+	TransitionSubmission(ID string, payload TransitionSubmissionPayload) (*TransitionSubmissionResponse, error)
+	BulkApproveSubmissions(payload BulkApproveSubmissionsPayload) error
 	TransitionStudy(ID, action string) (*TransitionStudyResponse, error)
 	UpdateStudy(ID string, study any) (*model.Study, error)
 	GetStudySubmissionCounts(ID string) (*model.SubmissionCounts, error)
@@ -361,6 +363,30 @@ func (c *Client) RequestSubmissionReturn(ID string, reasons []string) (*RequestS
 	}
 
 	return &response, nil
+}
+
+// TransitionSubmission will transition a submission to a new state.
+func (c *Client) TransitionSubmission(ID string, payload TransitionSubmissionPayload) (*TransitionSubmissionResponse, error) {
+	var response TransitionSubmissionResponse
+
+	url := fmt.Sprintf("/api/v1/submissions/%s/transition/", ID)
+	_, err := c.Execute(http.MethodPost, url, payload, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to transition submission: %s", err)
+	}
+
+	return &response, nil
+}
+
+// BulkApproveSubmissions will bulk approve multiple submissions.
+func (c *Client) BulkApproveSubmissions(payload BulkApproveSubmissionsPayload) error {
+	url := "/api/v1/submissions/bulk-approve/"
+	_, err := c.Execute(http.MethodPost, url, payload, nil)
+	if err != nil {
+		return fmt.Errorf("unable to bulk approve submissions: %s", err)
+	}
+
+	return nil
 }
 
 // TransitionStudy will move the study status to a desired state.

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -48,6 +48,28 @@ type UpdateHookPayload struct {
 	IsEnabled *bool   `json:"is_enabled,omitempty"`
 }
 
+// CompletionCodeData represents the data for a dynamic payment completion code.
+type CompletionCodeData struct {
+	PercentageOfReward   float64 `json:"percentage_of_reward"`
+	MessageToParticipant string  `json:"message_to_participant,omitempty"`
+}
+
+// TransitionSubmissionPayload represents the JSON payload for transitioning a submission.
+type TransitionSubmissionPayload struct {
+	Action             string              `json:"action"`
+	Message            string              `json:"message,omitempty"`
+	RejectionCategory  string              `json:"rejection_category,omitempty"`
+	CompletionCode     string              `json:"completion_code,omitempty"`
+	CompletionCodeData *CompletionCodeData `json:"completion_code_data,omitempty"`
+}
+
+// BulkApproveSubmissionsPayload represents the JSON payload for bulk approving submissions.
+type BulkApproveSubmissionsPayload struct {
+	SubmissionIDs  []string `json:"submission_ids,omitempty"`
+	StudyID        string   `json:"study_id,omitempty"`
+	ParticipantIDs []string `json:"participant_ids,omitempty"`
+}
+
 // CreateAITaskBuilderDatasetPayload represents the request for creating a dataset
 type CreateAITaskBuilderDatasetPayload struct {
 	Name        string `json:"name"`

--- a/client/responses.go
+++ b/client/responses.go
@@ -83,6 +83,17 @@ type ListFiltersResponse struct {
 	*JSONAPIMeta
 }
 
+// TransitionSubmissionResponse is the response for transitioning a submission.
+type TransitionSubmissionResponse struct {
+	ID          string  `json:"id"`
+	CompletedAt *string `json:"completed_at"`
+	EnteredCode *string `json:"entered_code"`
+	Participant string  `json:"participant"`
+	StartedAt   string  `json:"started_at"`
+	Status      string  `json:"status"`
+	StudyID     string  `json:"study_id"`
+}
+
 // RequestSubmissionReturnResponse is the response for requesting a submission return.
 type RequestSubmissionReturnResponse struct {
 	ID              string  `json:"id"`

--- a/cmd/submission/bulk_approve.go
+++ b/cmd/submission/bulk_approve.go
@@ -3,6 +3,8 @@ package submission
 import (
 	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/spf13/cobra"
@@ -13,6 +15,7 @@ type BulkApproveOptions struct {
 	SubmissionIDs  []string
 	StudyID        string
 	ParticipantIDs []string
+	File           string
 }
 
 // NewBulkApproveCommand creates a new `submission bulk-approve` command.
@@ -26,12 +29,21 @@ func NewBulkApproveCommand(c client.API, w io.Writer) *cobra.Command {
 
 You can approve submissions in two ways:
 
-1. By submission IDs: provide one or more --submission-id flags
-2. By study and participant IDs: provide a --study flag and one or more --participant-id flags
+1. By submission IDs: provide one or more --submission-id flags or a file with --file
+2. By study and participant IDs: provide a --study flag with --participant-id flags or a file with --file
+
+When using --file, the file should contain one ID per line. By default, IDs are
+treated as submission IDs. Use --study together with --file to treat IDs as
+participant IDs instead.
 
 The approval is processed asynchronously.`,
-		Example: `  prolific submission bulk-approve -i <submission_id> -i <submission_id>
-  prolific submission bulk-approve -s <study_id> -p <participant_id> -p <participant_id>`,
+		Example: `  # Approve by submission IDs
+  prolific submission bulk-approve -i <submission_id> -i <submission_id>
+  prolific submission bulk-approve -f submissions.csv
+
+  # Approve by study and participant IDs
+  prolific submission bulk-approve -s <study_id> -p <participant_id> -p <participant_id>
+  prolific submission bulk-approve -s <study_id> -f participants.csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := bulkApproveSubmissions(c, opts, w)
 			if err != nil {
@@ -44,8 +56,9 @@ The approval is processed asynchronously.`,
 
 	flags := cmd.Flags()
 	flags.StringArrayVarP(&opts.SubmissionIDs, "submission-id", "i", nil, "Submission ID to approve (can be specified multiple times)")
-	flags.StringVarP(&opts.StudyID, "study", "s", "", "Study ID (required with --participant-id)")
+	flags.StringVarP(&opts.StudyID, "study", "s", "", "Study ID (required with --participant-id, optional with --file)")
 	flags.StringArrayVarP(&opts.ParticipantIDs, "participant-id", "p", nil, "Participant ID to approve (can be specified multiple times, requires --study)")
+	flags.StringVarP(&opts.File, "file", "f", "", "Path to a file containing one ID per line")
 
 	return cmd
 }
@@ -53,6 +66,25 @@ The approval is processed asynchronously.`,
 func bulkApproveSubmissions(c client.API, opts BulkApproveOptions, w io.Writer) error {
 	hasSubmissionIDs := len(opts.SubmissionIDs) > 0
 	hasParticipantIDs := len(opts.ParticipantIDs) > 0
+	hasFile := opts.File != ""
+
+	if hasFile && (hasSubmissionIDs || hasParticipantIDs) {
+		return fmt.Errorf("cannot use --file together with --submission-id or --participant-id")
+	}
+
+	if hasFile {
+		ids, err := parseIDFile(opts.File)
+		if err != nil {
+			return err
+		}
+		if opts.StudyID != "" {
+			opts.ParticipantIDs = ids
+		} else {
+			opts.SubmissionIDs = ids
+		}
+		hasSubmissionIDs = len(opts.SubmissionIDs) > 0
+		hasParticipantIDs = len(opts.ParticipantIDs) > 0
+	}
 
 	if hasSubmissionIDs && (hasParticipantIDs || opts.StudyID != "") {
 		return fmt.Errorf("cannot use --submission-id together with --study or --participant-id")
@@ -60,9 +92,9 @@ func bulkApproveSubmissions(c client.API, opts BulkApproveOptions, w io.Writer) 
 
 	if !hasSubmissionIDs && !hasParticipantIDs {
 		if opts.StudyID != "" {
-			return fmt.Errorf("--participant-id is required when using --study")
+			return fmt.Errorf("--participant-id or --file is required when using --study")
 		}
-		return fmt.Errorf("you must provide either --submission-id or --study and --participant-id")
+		return fmt.Errorf("you must provide either --submission-id, --study and --participant-id, or --file")
 	}
 
 	if hasParticipantIDs && opts.StudyID == "" {
@@ -83,4 +115,31 @@ func bulkApproveSubmissions(c client.API, opts BulkApproveOptions, w io.Writer) 
 	fmt.Fprintln(w, "The request to bulk approve has been made successfully.")
 
 	return nil
+}
+
+func parseIDFile(filePath string) ([]string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file: %w", err)
+	}
+
+	content := strings.TrimRight(string(data), "\n\r ")
+	if content == "" {
+		return nil, fmt.Errorf("file is empty: %s", filePath)
+	}
+
+	var ids []string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		ids = append(ids, line)
+	}
+
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no valid entries found in file: %s", filePath)
+	}
+
+	return ids, nil
 }

--- a/cmd/submission/bulk_approve.go
+++ b/cmd/submission/bulk_approve.go
@@ -1,0 +1,86 @@
+package submission
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+// BulkApproveOptions is the options for bulk approving submissions.
+type BulkApproveOptions struct {
+	SubmissionIDs  []string
+	StudyID        string
+	ParticipantIDs []string
+}
+
+// NewBulkApproveCommand creates a new `submission bulk-approve` command.
+func NewBulkApproveCommand(c client.API, w io.Writer) *cobra.Command {
+	var opts BulkApproveOptions
+
+	cmd := &cobra.Command{
+		Use:   "bulk-approve",
+		Short: "Bulk approve multiple submissions",
+		Long: `Bulk approve multiple submissions at once.
+
+You can approve submissions in two ways:
+
+1. By submission IDs: provide one or more --submission-id flags
+2. By study and participant IDs: provide a --study flag and one or more --participant-id flags
+
+The approval is processed asynchronously.`,
+		Example: `  prolific submission bulk-approve -i <submission_id> -i <submission_id>
+  prolific submission bulk-approve -s <study_id> -p <participant_id> -p <participant_id>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := bulkApproveSubmissions(c, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringArrayVarP(&opts.SubmissionIDs, "submission-id", "i", nil, "Submission ID to approve (can be specified multiple times)")
+	flags.StringVarP(&opts.StudyID, "study", "s", "", "Study ID (required with --participant-id)")
+	flags.StringArrayVarP(&opts.ParticipantIDs, "participant-id", "p", nil, "Participant ID to approve (can be specified multiple times, requires --study)")
+
+	return cmd
+}
+
+func bulkApproveSubmissions(c client.API, opts BulkApproveOptions, w io.Writer) error {
+	hasSubmissionIDs := len(opts.SubmissionIDs) > 0
+	hasParticipantIDs := len(opts.ParticipantIDs) > 0
+
+	if hasSubmissionIDs && (hasParticipantIDs || opts.StudyID != "") {
+		return fmt.Errorf("cannot use --submission-id together with --study or --participant-id")
+	}
+
+	if !hasSubmissionIDs && !hasParticipantIDs {
+		if opts.StudyID != "" {
+			return fmt.Errorf("--participant-id is required when using --study")
+		}
+		return fmt.Errorf("you must provide either --submission-id or --study and --participant-id")
+	}
+
+	if hasParticipantIDs && opts.StudyID == "" {
+		return fmt.Errorf("--study is required when using --participant-id")
+	}
+
+	payload := client.BulkApproveSubmissionsPayload{
+		SubmissionIDs:  opts.SubmissionIDs,
+		StudyID:        opts.StudyID,
+		ParticipantIDs: opts.ParticipantIDs,
+	}
+
+	err := c.BulkApproveSubmissions(payload)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w, "The request to bulk approve has been made successfully.")
+
+	return nil
+}

--- a/cmd/submission/bulk_approve_test.go
+++ b/cmd/submission/bulk_approve_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -13,6 +15,8 @@ import (
 	"github.com/prolific-oss/cli/cmd/submission"
 	"github.com/prolific-oss/cli/mock_client"
 )
+
+const bulkApproveSuccessMessage = "The request to bulk approve has been made successfully.\n"
 
 func TestNewBulkApproveCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -51,7 +55,7 @@ func TestBulkApproveCommandErrorsIfNoFlags(t *testing.T) {
 
 	writer.Flush()
 
-	expected := "error: you must provide either --submission-id or --study and --participant-id"
+	expected := "error: you must provide either --submission-id, --study and --participant-id, or --file"
 
 	if err.Error() != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
@@ -104,7 +108,7 @@ func TestBulkApproveCommandErrorsIfStudyWithoutParticipantIDs(t *testing.T) {
 
 	writer.Flush()
 
-	expected := "error: --participant-id is required when using --study"
+	expected := "error: --participant-id or --file is required when using --study"
 
 	if err.Error() != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
@@ -164,10 +168,8 @@ func TestBulkApproveCommandApprovesBySubmissionIDs(t *testing.T) {
 	writer.Flush()
 	actual := b.String()
 
-	expected := "The request to bulk approve has been made successfully.\n"
-
-	if actual != expected {
-		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	if actual != bulkApproveSuccessMessage {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", bulkApproveSuccessMessage, actual)
 	}
 }
 
@@ -200,10 +202,8 @@ func TestBulkApproveCommandApprovesByStudyAndParticipantIDs(t *testing.T) {
 	writer.Flush()
 	actual := b.String()
 
-	expected := "The request to bulk approve has been made successfully.\n"
-
-	if actual != expected {
-		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	if actual != bulkApproveSuccessMessage {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", bulkApproveSuccessMessage, actual)
 	}
 }
 
@@ -233,5 +233,188 @@ func TestBulkApproveCommandReturnsErrorIfApprovalFails(t *testing.T) {
 
 	if err.Error() != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestBulkApproveCommandApprovesByFileAsSubmissionIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Eq(client.BulkApproveSubmissionsPayload{
+			SubmissionIDs: []string{"sub-1", "sub-2", "sub-3"},
+		})).
+		Return(nil).
+		MaxTimes(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "submissions.csv")
+	if err := os.WriteFile(filePath, []byte("sub-1\nsub-2\nsub-3\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	if actual != bulkApproveSuccessMessage {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", bulkApproveSuccessMessage, actual)
+	}
+}
+
+func TestBulkApproveCommandApprovesByFileAsParticipantIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Eq(client.BulkApproveSubmissionsPayload{
+			StudyID:        "study-1",
+			ParticipantIDs: []string{"part-1", "part-2"},
+		})).
+		Return(nil).
+		MaxTimes(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "participants.csv")
+	if err := os.WriteFile(filePath, []byte("part-1\npart-2\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	_ = cmd.Flags().Set("study", "study-1")
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	if actual != bulkApproveSuccessMessage {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", bulkApproveSuccessMessage, actual)
+	}
+}
+
+func TestBulkApproveCommandErrorsIfFileWithInlineIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Any()).
+		MaxTimes(0)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "submissions.csv")
+	if err := os.WriteFile(filePath, []byte("sub-1\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	_ = cmd.Flags().Set("submission-id", "sub-1")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: cannot use --file together with --submission-id or --participant-id"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func assertBulkApproveFileError(t *testing.T, filePath, expectedSubstring string) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), expectedSubstring) {
+		t.Fatalf("expected error to contain '%s', got\n'%s'\n", expectedSubstring, err.Error())
+	}
+}
+
+func TestBulkApproveCommandErrorsIfFileIsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "empty.csv")
+	if err := os.WriteFile(filePath, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	assertBulkApproveFileError(t, filePath, "file is empty")
+}
+
+func TestBulkApproveCommandErrorsIfFileNotFound(t *testing.T) {
+	assertBulkApproveFileError(t, "/nonexistent/path/file.csv", "unable to read file")
+}
+
+func TestBulkApproveCommandFileSkipsBlankLines(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Eq(client.BulkApproveSubmissionsPayload{
+			SubmissionIDs: []string{"sub-1", "sub-2"},
+		})).
+		Return(nil).
+		MaxTimes(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "submissions.csv")
+	if err := os.WriteFile(filePath, []byte("sub-1\n\n  \nsub-2\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
 	}
 }

--- a/cmd/submission/bulk_approve_test.go
+++ b/cmd/submission/bulk_approve_test.go
@@ -1,0 +1,237 @@
+package submission_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/submission"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+func TestNewBulkApproveCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := submission.NewBulkApproveCommand(c, os.Stdout)
+
+	use := "bulk-approve"
+	short := "Bulk approve multiple submissions"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestBulkApproveCommandErrorsIfNoFlags(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: you must provide either --submission-id or --study and --participant-id"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestBulkApproveCommandErrorsIfMixedFlags(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("submission-id", "sub-1")
+	_ = cmd.Flags().Set("study", "study-1")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: cannot use --submission-id together with --study or --participant-id"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestBulkApproveCommandErrorsIfStudyWithoutParticipantIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("study", "study-1")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: --participant-id is required when using --study"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestBulkApproveCommandErrorsIfParticipantIDsWithoutStudy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("participant-id", "part-1")
+	err := cmd.RunE(cmd, nil)
+
+	writer.Flush()
+
+	expected := "error: --study is required when using --participant-id"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestBulkApproveCommandApprovesBySubmissionIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Eq(client.BulkApproveSubmissionsPayload{
+			SubmissionIDs: []string{"sub-1", "sub-2"},
+		})).
+		Return(nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("submission-id", "sub-1")
+	_ = cmd.Flags().Set("submission-id", "sub-2")
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	expected := "The request to bulk approve has been made successfully.\n"
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestBulkApproveCommandApprovesByStudyAndParticipantIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Eq(client.BulkApproveSubmissionsPayload{
+			StudyID:        "study-1",
+			ParticipantIDs: []string{"part-1", "part-2"},
+		})).
+		Return(nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("study", "study-1")
+	_ = cmd.Flags().Set("participant-id", "part-1")
+	_ = cmd.Flags().Set("participant-id", "part-2")
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	expected := "The request to bulk approve has been made successfully.\n"
+
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestBulkApproveCommandReturnsErrorIfApprovalFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	errorMessage := "Unable to bulk approve submissions"
+
+	c.
+		EXPECT().
+		BulkApproveSubmissions(gomock.Eq(client.BulkApproveSubmissionsPayload{
+			SubmissionIDs: []string{"sub-1"},
+		})).
+		Return(errors.New(errorMessage)).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewBulkApproveCommand(c, writer)
+	_ = cmd.Flags().Set("submission-id", "sub-1")
+	err := cmd.RunE(cmd, nil)
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}

--- a/cmd/submission/submission.go
+++ b/cmd/submission/submission.go
@@ -22,6 +22,8 @@ commands allow you to manage those submissions.
 	cmd.AddCommand(
 		NewListCommand(client, w),
 		NewRequestReturnCommand(client, w),
+		NewTransitionCommand(client, w),
+		NewBulkApproveCommand(client, w),
 	)
 	return cmd
 }

--- a/cmd/submission/transition.go
+++ b/cmd/submission/transition.go
@@ -1,0 +1,144 @@
+package submission
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+)
+
+var submissionTransitionActions = []string{
+	"APPROVE",
+	"COMPLETE",
+	"REJECT",
+	"RETURN",
+	"SCREEN_OUT",
+	"START",
+	"UNREJECT",
+	"UNRETURN",
+}
+
+var rejectionCategories = []string{
+	"TOO_QUICKLY",
+	"TOO_SLOWLY",
+	"FAILED_INSTRUCTIONS",
+	"INCOMP_LONGITUDINAL",
+	"FAILED_CHECK",
+	"LOW_EFFORT",
+	"MALINGERING",
+	"NO_CODE",
+	"BAD_CODE",
+	"NO_DATA",
+	"UNSUPP_DEVICE",
+	"OTHER",
+}
+
+// TransitionOptions is the options for transitioning a submission.
+type TransitionOptions struct {
+	SubmissionID         string
+	Action               string
+	Message              string
+	RejectionCategory    string
+	CompletionCode       string
+	PercentageOfReward   float64
+	MessageToParticipant string
+}
+
+// NewTransitionCommand creates a new `submission transition` command.
+func NewTransitionCommand(c client.API, w io.Writer) *cobra.Command {
+	var opts TransitionOptions
+
+	cmd := &cobra.Command{
+		Use:   "transition",
+		Short: "Transition the status of a submission",
+		Long: `Transition a submission to a new state.
+
+You can approve, complete, reject, return, or perform other state transitions on a submission.
+
+When rejecting a submission, you must provide a message (at least 100 characters)
+and a rejection category.
+
+When completing a submission, you must provide a completion code. If the completion
+code has a DYNAMIC_PAYMENT action, you must also provide the percentage of reward.`,
+		Example: `  prolific submission transition <submission_id> -a APPROVE
+  prolific submission transition <submission_id> -a REJECT -m "Your response did not follow the instructions provided in the study description" -R FAILED_INSTRUCTIONS
+  prolific submission transition <submission_id> -a COMPLETE --completion-code MY_CODE
+  prolific submission transition <submission_id> -a COMPLETE --completion-code MY_CODE --percentage-of-reward 50`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.SubmissionID = args[0]
+
+			err := transitionSubmission(c, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Action, "action", "a", "", fmt.Sprintf("Action to perform on the submission (%s)", strings.Join(submissionTransitionActions, ", ")))
+	flags.StringVarP(&opts.Message, "message", "m", "", "Message to send to the participant (required for REJECT, min 100 characters)")
+	flags.StringVarP(&opts.RejectionCategory, "rejection-category", "R", "", fmt.Sprintf("Rejection category (required for REJECT): %s", strings.Join(rejectionCategories, ", ")))
+	flags.StringVar(&opts.CompletionCode, "completion-code", "", "Completion code (required for COMPLETE)")
+	flags.Float64Var(&opts.PercentageOfReward, "percentage-of-reward", 0, "Percentage of reward for dynamic payment (8-99, used with COMPLETE)")
+	flags.StringVar(&opts.MessageToParticipant, "message-to-participant", "", "Message to participant for dynamic payment (used with COMPLETE)")
+
+	_ = cmd.MarkFlagRequired("action")
+
+	return cmd
+}
+
+func transitionSubmission(c client.API, opts TransitionOptions, w io.Writer) error {
+	if !slices.Contains(submissionTransitionActions, opts.Action) {
+		return fmt.Errorf("invalid action %q, must be one of: %s", opts.Action, strings.Join(submissionTransitionActions, ", "))
+	}
+
+	if opts.Action == "REJECT" {
+		if opts.Message == "" {
+			return fmt.Errorf("message is required when rejecting a submission")
+		}
+		if opts.RejectionCategory == "" {
+			return fmt.Errorf("rejection-category is required when rejecting a submission")
+		}
+		if !slices.Contains(rejectionCategories, opts.RejectionCategory) {
+			return fmt.Errorf("invalid rejection category %q, must be one of: %s", opts.RejectionCategory, strings.Join(rejectionCategories, ", "))
+		}
+	}
+
+	if opts.Action == "COMPLETE" {
+		if opts.CompletionCode == "" {
+			return fmt.Errorf("completion-code is required when completing a submission")
+		}
+	}
+
+	payload := client.TransitionSubmissionPayload{
+		Action:            opts.Action,
+		Message:           opts.Message,
+		RejectionCategory: opts.RejectionCategory,
+		CompletionCode:    opts.CompletionCode,
+	}
+
+	if opts.PercentageOfReward > 0 {
+		payload.CompletionCodeData = &client.CompletionCodeData{
+			PercentageOfReward:   opts.PercentageOfReward,
+			MessageToParticipant: opts.MessageToParticipant,
+		}
+	}
+
+	response, err := c.TransitionSubmission(opts.SubmissionID, payload)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 1, 1, ' ', 0)
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "ID", "Study", "Participant", "Status")
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", response.ID, response.StudyID, response.Participant, response.Status)
+
+	return tw.Flush()
+}

--- a/cmd/submission/transition_test.go
+++ b/cmd/submission/transition_test.go
@@ -1,0 +1,399 @@
+package submission_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/submission"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+func TestNewTransitionCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := submission.NewTransitionCommand(c, os.Stdout)
+
+	use := "transition"
+	short := "Transition the status of a submission"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestTransitionCommandErrorsIfInvalidAction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Any(), gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", "FOOBAR")
+	err := cmd.RunE(cmd, []string{testSubmissionID})
+
+	writer.Flush()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := `error: invalid action "FOOBAR"`
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected error to contain\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestTransitionCommandErrorsIfRejectWithoutMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Any(), gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", "REJECT")
+	_ = cmd.Flags().Set("rejection-category", "FAILED_INSTRUCTIONS")
+	err := cmd.RunE(cmd, []string{testSubmissionID})
+
+	writer.Flush()
+
+	expected := "error: message is required when rejecting a submission"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestTransitionCommandErrorsIfRejectWithoutCategory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Any(), gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", "REJECT")
+	_ = cmd.Flags().Set("message", "This is a rejection message that needs to be at least 100 characters long to satisfy the API requirement for rejections")
+	err := cmd.RunE(cmd, []string{testSubmissionID})
+
+	writer.Flush()
+
+	expected := "error: rejection-category is required when rejecting a submission"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestTransitionCommandTransitionsSubmission(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	submissionID := testSubmissionID
+	action := "APPROVE"
+
+	r := client.TransitionSubmissionResponse{
+		ID:          submissionID,
+		Status:      "APPROVED",
+		Participant: "participant-123",
+		StudyID:     "study-456",
+	}
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Eq(submissionID), gomock.Eq(client.TransitionSubmissionPayload{
+			Action: action,
+		})).
+		Return(&r, nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", action)
+	err := cmd.RunE(cmd, []string{submissionID})
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	if !strings.Contains(actual, submissionID) {
+		t.Fatalf("expected output to contain submission ID %s, got\n'%s'\n", submissionID, actual)
+	}
+	if !strings.Contains(actual, "APPROVED") {
+		t.Fatalf("expected output to contain status APPROVED, got\n'%s'\n", actual)
+	}
+	if !strings.Contains(actual, "participant-123") {
+		t.Fatalf("expected output to contain participant ID, got\n'%s'\n", actual)
+	}
+	if !strings.Contains(actual, "study-456") {
+		t.Fatalf("expected output to contain study ID, got\n'%s'\n", actual)
+	}
+}
+
+func TestTransitionCommandTransitionsSubmissionWithRejection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	submissionID := testSubmissionID
+	action := "REJECT"
+	message := "Your response did not follow the instructions provided in the study description which is why we are rejecting"
+	category := "FAILED_INSTRUCTIONS"
+
+	r := client.TransitionSubmissionResponse{
+		ID:          submissionID,
+		Status:      "REJECTED",
+		Participant: "participant-123",
+	}
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Eq(submissionID), gomock.Eq(client.TransitionSubmissionPayload{
+			Action:            action,
+			Message:           message,
+			RejectionCategory: category,
+		})).
+		Return(&r, nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", action)
+	_ = cmd.Flags().Set("message", message)
+	_ = cmd.Flags().Set("rejection-category", category)
+	err := cmd.RunE(cmd, []string{submissionID})
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	if !strings.Contains(actual, submissionID) {
+		t.Fatalf("expected output to contain submission ID %s, got\n'%s'\n", submissionID, actual)
+	}
+	if !strings.Contains(actual, "REJECTED") {
+		t.Fatalf("expected output to contain status REJECTED, got\n'%s'\n", actual)
+	}
+}
+
+func TestTransitionCommandErrorsIfInvalidRejectionCategory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Any(), gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", "REJECT")
+	_ = cmd.Flags().Set("message", "This is a rejection message that needs to be at least 100 characters long to satisfy the API requirement for rejections")
+	_ = cmd.Flags().Set("rejection-category", "INVALID_CATEGORY")
+	err := cmd.RunE(cmd, []string{testSubmissionID})
+
+	writer.Flush()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := `error: invalid rejection category "INVALID_CATEGORY"`
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected error to contain\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestTransitionCommandErrorsIfCompleteWithoutCode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Any(), gomock.Any()).
+		MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", "COMPLETE")
+	err := cmd.RunE(cmd, []string{testSubmissionID})
+
+	writer.Flush()
+
+	expected := "error: completion-code is required when completing a submission"
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestTransitionCommandTransitionsSubmissionWithComplete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	submissionID := testSubmissionID
+	action := "COMPLETE"
+	completionCode := "MY_CODE"
+
+	r := client.TransitionSubmissionResponse{
+		ID:          submissionID,
+		Status:      "APPROVED",
+		Participant: "participant-123",
+	}
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Eq(submissionID), gomock.Eq(client.TransitionSubmissionPayload{
+			Action:         action,
+			CompletionCode: completionCode,
+		})).
+		Return(&r, nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", action)
+	_ = cmd.Flags().Set("completion-code", completionCode)
+	err := cmd.RunE(cmd, []string{submissionID})
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	if !strings.Contains(actual, submissionID) {
+		t.Fatalf("expected output to contain submission ID %s, got\n'%s'\n", submissionID, actual)
+	}
+	if !strings.Contains(actual, "APPROVED") {
+		t.Fatalf("expected output to contain status, got\n'%s'\n", actual)
+	}
+}
+
+func TestTransitionCommandTransitionsSubmissionWithDynamicPayment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	submissionID := testSubmissionID
+	action := "COMPLETE"
+	completionCode := "MY_CODE"
+
+	r := client.TransitionSubmissionResponse{
+		ID:          submissionID,
+		Status:      "APPROVED",
+		Participant: "participant-123",
+	}
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Eq(submissionID), gomock.Eq(client.TransitionSubmissionPayload{
+			Action:         action,
+			CompletionCode: completionCode,
+			CompletionCodeData: &client.CompletionCodeData{
+				PercentageOfReward:   50,
+				MessageToParticipant: "Good job",
+			},
+		})).
+		Return(&r, nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", action)
+	_ = cmd.Flags().Set("completion-code", completionCode)
+	_ = cmd.Flags().Set("percentage-of-reward", "50")
+	_ = cmd.Flags().Set("message-to-participant", "Good job")
+	err := cmd.RunE(cmd, []string{submissionID})
+	if err != nil {
+		t.Fatalf("was not expected error, got %v", err)
+	}
+
+	writer.Flush()
+	actual := b.String()
+
+	if !strings.Contains(actual, submissionID) {
+		t.Fatalf("expected output to contain submission ID %s, got\n'%s'\n", submissionID, actual)
+	}
+}
+
+func TestTransitionCommandReturnsErrorIfTransitionFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	errorMessage := "Unable to transition submission"
+	submissionID := testSubmissionID
+
+	c.
+		EXPECT().
+		TransitionSubmission(gomock.Eq(submissionID), gomock.Eq(client.TransitionSubmissionPayload{
+			Action: "APPROVE",
+		})).
+		Return(nil, errors.New(errorMessage)).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := submission.NewTransitionCommand(c, writer)
+	_ = cmd.Flags().Set("action", "APPROVE")
+	err := cmd.RunE(cmd, []string{submissionID})
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -35,6 +35,20 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
+// BulkApproveSubmissions mocks base method.
+func (m *MockAPI) BulkApproveSubmissions(payload client.BulkApproveSubmissionsPayload) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkApproveSubmissions", payload)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkApproveSubmissions indicates an expected call of BulkApproveSubmissions.
+func (mr *MockAPIMockRecorder) BulkApproveSubmissions(payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkApproveSubmissions", reflect.TypeOf((*MockAPI)(nil).BulkApproveSubmissions), payload)
+}
+
 // BulkSendMessage mocks base method.
 func (m *MockAPI) BulkSendMessage(ids []string, body, studyID string) error {
 	m.ctrl.T.Helper()
@@ -973,6 +987,21 @@ func (m *MockAPI) TransitionStudy(ID, action string) (*client.TransitionStudyRes
 func (mr *MockAPIMockRecorder) TransitionStudy(ID, action interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitionStudy", reflect.TypeOf((*MockAPI)(nil).TransitionStudy), ID, action)
+}
+
+// TransitionSubmission mocks base method.
+func (m *MockAPI) TransitionSubmission(ID string, payload client.TransitionSubmissionPayload) (*client.TransitionSubmissionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransitionSubmission", ID, payload)
+	ret0, _ := ret[0].(*client.TransitionSubmissionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransitionSubmission indicates an expected call of TransitionSubmission.
+func (mr *MockAPIMockRecorder) TransitionSubmission(ID, payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitionSubmission", reflect.TypeOf((*MockAPI)(nil).TransitionSubmission), ID, payload)
 }
 
 // UpdateCollection mocks base method.


### PR DESCRIPTION
Summary

  Implements two new CLI commands for managing submission states, closing the gap with the Prolific API:

  - prolific submission transition <id> -a <ACTION> — Transition a submission to a new state (approve, reject, complete, return, screen out, etc.).
  Supports rejection with message and category, completion codes, and dynamic payments.
  - prolific submission bulk-approve — Bulk approve submissions by submission IDs (-i) or by study + participant IDs (-s / -p).

  Changes

  - cmd/submission/transition.go — Transition command with client-side validation for action-specific requirements
  - cmd/submission/bulk_approve.go — Bulk approve command with two mutually exclusive input modes
  - client/client.go — TransitionSubmission and BulkApproveSubmissions API methods
  - client/payloads.go — Request payload types matching the OpenAPI spec
  - client/responses.go — TransitionSubmissionResponse aligned with the API's Submission schema

  Test plan

  - Unit tests for all validation paths and success cases
  - make lint and go test ./... pass
  - Manually tested against test environment (transition approve + bulk approve)

  Closes #363