### PR TITLE
feat(DCP-2668): add participant group remove command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -79,6 +79,7 @@ type API interface {
 	GetParticipantGroups(workspaceID string, limit, offset int) (*ListParticipantGroupsResponse, error)
 	GetParticipantGroup(groupID string) (*ViewParticipantGroupResponse, error)
 	CreateParticipantGroup(group model.CreateParticipantGroup) (*CreateParticipantGroupResponse, error)
+	RemoveParticipantGroupMembers(groupID string, participantIDs []string) error
 
 	GetFilters() (*ListFiltersResponse, error)
 
@@ -830,6 +831,20 @@ func (c *Client) CreateParticipantGroup(group model.CreateParticipantGroup) (*Cr
 	}
 
 	return &response, nil
+}
+
+func (c *Client) RemoveParticipantGroupMembers(groupID string, participantIDs []string) error {
+	payload := RemoveParticipantGroupMembersPayload{
+		ParticipantIDs: participantIDs,
+	}
+
+	url := fmt.Sprintf("/api/v1/participant-groups/%s/participants/", groupID)
+	_, err := c.Execute(http.MethodDelete, url, payload, nil)
+	if err != nil {
+		return fmt.Errorf("unable to remove participants from group %s: %s", groupID, err)
+	}
+
+	return nil
 }
 
 func (c *Client) GetFilters() (*ListFiltersResponse, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -79,7 +79,7 @@ type API interface {
 	GetParticipantGroups(workspaceID string, limit, offset int) (*ListParticipantGroupsResponse, error)
 	GetParticipantGroup(groupID string) (*ViewParticipantGroupResponse, error)
 	CreateParticipantGroup(group model.CreateParticipantGroup) (*CreateParticipantGroupResponse, error)
-	RemoveParticipantGroupMembers(groupID string, participantIDs []string) error
+	RemoveParticipantGroupMembers(groupID string, participantIDs []string) (*ViewParticipantGroupResponse, error)
 
 	GetFilters() (*ListFiltersResponse, error)
 
@@ -833,18 +833,22 @@ func (c *Client) CreateParticipantGroup(group model.CreateParticipantGroup) (*Cr
 	return &response, nil
 }
 
-func (c *Client) RemoveParticipantGroupMembers(groupID string, participantIDs []string) error {
+func (c *Client) RemoveParticipantGroupMembers(groupID string, participantIDs []string) (*ViewParticipantGroupResponse, error) {
 	payload := RemoveParticipantGroupMembersPayload{
 		ParticipantIDs: participantIDs,
 	}
+	var response ViewParticipantGroupResponse
 
 	url := fmt.Sprintf("/api/v1/participant-groups/%s/participants/", groupID)
-	_, err := c.Execute(http.MethodDelete, url, payload, nil)
+	httpResponse, err := c.Execute(http.MethodDelete, url, payload, &response)
 	if err != nil {
-		return fmt.Errorf("unable to remove participants from group %s: %s", groupID, err)
+		return nil, fmt.Errorf("unable to remove participants from group %s: %s", groupID, err)
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unable to remove participants from group %s, status code: %v", groupID, httpResponse.StatusCode)
 	}
 
-	return nil
+	return &response, nil
 }
 
 func (c *Client) GetFilters() (*ListFiltersResponse, error) {

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -70,6 +70,11 @@ type BulkApproveSubmissionsPayload struct {
 	ParticipantIDs []string `json:"participant_ids,omitempty"`
 }
 
+// RemoveParticipantGroupMembersPayload represents the JSON payload for removing participants from a group.
+type RemoveParticipantGroupMembersPayload struct {
+	ParticipantIDs []string `json:"participant_ids"`
+}
+
 // CreateAITaskBuilderDatasetPayload represents the request for creating a dataset
 type CreateAITaskBuilderDatasetPayload struct {
 	Name        string `json:"name"`

--- a/cmd/participantgroup/create.go
+++ b/cmd/participantgroup/create.go
@@ -58,7 +58,7 @@ $ prolific participant create -N "My Group" -w <workspace_id> -p <participant_id
 	flags.StringVarP(&opts.Name, "name", "N", "", "The name of the participant group.")
 	flags.StringVarP(&opts.WorkspaceID, "workspace", "w", viper.GetString("workspace"), "The ID of the workspace to create the participant group in.")
 	flags.StringVarP(&opts.Description, "description", "d", "", "The description of the participant group.")
-	flags.StringSliceVarP(&opts.ParticipantIDs, "participant-id", "p", nil, "The ID of a participant to add to the group. Can be specified multiple times.")
+	flags.StringArrayVarP(&opts.ParticipantIDs, "participant-id", "p", nil, "The ID of a participant to add to the group. Can be specified multiple times.")
 
 	return cmd
 }

--- a/cmd/participantgroup/participant_group.go
+++ b/cmd/participantgroup/participant_group.go
@@ -30,6 +30,7 @@ Participant groups allow you do the following:
 		NewListCommand("list", client, w),
 		NewViewCommand("view", client, w),
 		NewCreateCommand("create", client, w),
+		NewRemoveCommand("remove", client, w),
 	)
 	return cmd
 }

--- a/cmd/participantgroup/remove.go
+++ b/cmd/participantgroup/remove.go
@@ -1,0 +1,90 @@
+package participantgroup
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/shared"
+	"github.com/spf13/cobra"
+)
+
+// RemoveOptions are the options for removing participants from a group.
+type RemoveOptions struct {
+	Args           []string
+	ParticipantIDs []string
+	File           string
+}
+
+// NewRemoveCommand creates a new command for removing participants from a participant group.
+func NewRemoveCommand(commandName string, client client.API, w io.Writer) *cobra.Command {
+	var opts RemoveOptions
+
+	cmd := &cobra.Command{
+		Use:   commandName + " <group-id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove participants from a participant group",
+		Long: `Remove one or more participants from an existing participant group.
+
+You can specify participants in two ways:
+
+1. Inline: provide one or more --participant-id flags
+2. File: provide a --file flag with a file containing one participant ID per line
+
+The two methods are mutually exclusive.`,
+		Example: `
+  # Remove participants by ID
+  prolific participant remove <group_id> -p <participant_id> -p <participant_id>
+
+  # Remove participants from a file (one ID per line)
+  prolific participant remove <group_id> -f participants.csv`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			err := removeParticipants(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err)
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringArrayVarP(&opts.ParticipantIDs, "participant-id", "p", nil, "The ID of a participant to remove. Can be specified multiple times.")
+	flags.StringVarP(&opts.File, "file", "f", "", "Path to a file containing one participant ID per line.")
+
+	return cmd
+}
+
+func removeParticipants(c client.API, opts RemoveOptions, w io.Writer) error {
+	groupID := opts.Args[0]
+
+	hasInlineIDs := len(opts.ParticipantIDs) > 0
+	hasFile := opts.File != ""
+
+	if hasFile && hasInlineIDs {
+		return fmt.Errorf("cannot use --file together with --participant-id")
+	}
+
+	if hasFile {
+		ids, err := shared.ParseIDFile(opts.File)
+		if err != nil {
+			return err
+		}
+		opts.ParticipantIDs = ids
+	}
+
+	if len(opts.ParticipantIDs) == 0 {
+		return fmt.Errorf("you must provide at least one participant ID via --participant-id or --file")
+	}
+
+	err := c.RemoveParticipantGroupMembers(groupID, opts.ParticipantIDs)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "Removed %d participant(s) from group %s\n", len(opts.ParticipantIDs), groupID)
+
+	return nil
+}

--- a/cmd/participantgroup/remove.go
+++ b/cmd/participantgroup/remove.go
@@ -79,12 +79,12 @@ func removeParticipants(c client.API, opts RemoveOptions, w io.Writer) error {
 		return fmt.Errorf("you must provide at least one participant ID via --participant-id or --file")
 	}
 
-	err := c.RemoveParticipantGroupMembers(groupID, opts.ParticipantIDs)
+	response, err := c.RemoveParticipantGroupMembers(groupID, opts.ParticipantIDs)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(w, "Removed %d participant(s) from group %s\n", len(opts.ParticipantIDs), groupID)
+	fmt.Fprintf(w, "Removed %d participant(s) from group %s (%d remaining)\n", len(opts.ParticipantIDs), groupID, len(response.Results))
 
 	return nil
 }

--- a/cmd/participantgroup/remove_test.go
+++ b/cmd/participantgroup/remove_test.go
@@ -1,0 +1,221 @@
+package participantgroup_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/cmd/participantgroup"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+const removeSuccessGroupID = "group-1"
+
+func TestNewRemoveCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, os.Stdout)
+
+	if cmd.Use != "remove <group-id>" {
+		t.Fatalf("expected use: 'remove <group-id>'; got %q", cmd.Use)
+	}
+	if cmd.Short != "Remove participants from a participant group" {
+		t.Fatalf("unexpected short description: %q", cmd.Short)
+	}
+}
+
+func TestRemoveCommandErrorsIfNoParticipants(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.EXPECT().RemoveParticipantGroupMembers(gomock.Any(), gomock.Any()).MaxTimes(0)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, writer)
+	cmd.SetArgs([]string{removeSuccessGroupID})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := "error: you must provide at least one participant ID via --participant-id or --file"
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestRemoveCommandErrorsIfFileAndInlineIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.EXPECT().RemoveParticipantGroupMembers(gomock.Any(), gomock.Any()).MaxTimes(0)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "participants.csv")
+	if err := os.WriteFile(filePath, []byte("part-1\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	_ = cmd.Flags().Set("participant-id", "part-1")
+	cmd.SetArgs([]string{removeSuccessGroupID})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := "error: cannot use --file together with --participant-id"
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestRemoveCommandRemovesByInlineIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		RemoveParticipantGroupMembers(
+			gomock.Eq(removeSuccessGroupID),
+			gomock.Eq([]string{"part-1", "part-2"}),
+		).
+		Return(nil).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, writer)
+	_ = cmd.Flags().Set("participant-id", "part-1")
+	_ = cmd.Flags().Set("participant-id", "part-2")
+	cmd.SetArgs([]string{removeSuccessGroupID})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	writer.Flush()
+
+	expected := "Removed 2 participant(s) from group group-1\n"
+	if b.String() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, b.String())
+	}
+}
+
+func TestRemoveCommandRemovesByFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		RemoveParticipantGroupMembers(
+			gomock.Eq(removeSuccessGroupID),
+			gomock.Eq([]string{"part-1", "part-2", "part-3"}),
+		).
+		Return(nil).
+		MaxTimes(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "participants.csv")
+	if err := os.WriteFile(filePath, []byte("part-1\npart-2\npart-3\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	cmd.SetArgs([]string{removeSuccessGroupID})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	writer.Flush()
+
+	expected := "Removed 3 participant(s) from group group-1\n"
+	if b.String() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, b.String())
+	}
+}
+
+func TestRemoveCommandReturnsErrorIfRemoveFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		RemoveParticipantGroupMembers(gomock.Any(), gomock.Any()).
+		Return(errors.New("api error")).
+		MaxTimes(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, writer)
+	_ = cmd.Flags().Set("participant-id", "part-1")
+	cmd.SetArgs([]string{removeSuccessGroupID})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := "error: api error"
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestRemoveCommandFileSkipsBlankLines(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		RemoveParticipantGroupMembers(
+			gomock.Eq(removeSuccessGroupID),
+			gomock.Eq([]string{"part-1", "part-2"}),
+		).
+		Return(nil).
+		MaxTimes(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "participants.csv")
+	if err := os.WriteFile(filePath, []byte("part-1\n\n  \npart-2\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := participantgroup.NewRemoveCommand("remove", c, writer)
+	_ = cmd.Flags().Set("file", filePath)
+	cmd.SetArgs([]string{removeSuccessGroupID})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/participantgroup/remove_test.go
+++ b/cmd/participantgroup/remove_test.go
@@ -9,11 +9,21 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
 	"github.com/prolific-oss/cli/cmd/participantgroup"
 	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
 )
 
 const removeSuccessGroupID = "group-1"
+
+func removeResponse(remaining ...string) *client.ViewParticipantGroupResponse {
+	memberships := make([]model.ParticipantGroupMembership, len(remaining))
+	for i, id := range remaining {
+		memberships[i] = model.ParticipantGroupMembership{ParticipantID: id}
+	}
+	return &client.ViewParticipantGroupResponse{Results: memberships}
+}
 
 func TestNewRemoveCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -97,7 +107,7 @@ func TestRemoveCommandRemovesByInlineIDs(t *testing.T) {
 			gomock.Eq(removeSuccessGroupID),
 			gomock.Eq([]string{"part-1", "part-2"}),
 		).
-		Return(nil).
+		Return(removeResponse("remaining-1"), nil).
 		MaxTimes(1)
 
 	var b bytes.Buffer
@@ -114,7 +124,7 @@ func TestRemoveCommandRemovesByInlineIDs(t *testing.T) {
 
 	writer.Flush()
 
-	expected := "Removed 2 participant(s) from group group-1\n"
+	expected := "Removed 2 participant(s) from group group-1 (1 remaining)\n"
 	if b.String() != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, b.String())
 	}
@@ -131,7 +141,7 @@ func TestRemoveCommandRemovesByFile(t *testing.T) {
 			gomock.Eq(removeSuccessGroupID),
 			gomock.Eq([]string{"part-1", "part-2", "part-3"}),
 		).
-		Return(nil).
+		Return(removeResponse(), nil).
 		MaxTimes(1)
 
 	dir := t.TempDir()
@@ -153,7 +163,7 @@ func TestRemoveCommandRemovesByFile(t *testing.T) {
 
 	writer.Flush()
 
-	expected := "Removed 3 participant(s) from group group-1\n"
+	expected := "Removed 3 participant(s) from group group-1 (0 remaining)\n"
 	if b.String() != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, b.String())
 	}
@@ -167,7 +177,7 @@ func TestRemoveCommandReturnsErrorIfRemoveFails(t *testing.T) {
 	c.
 		EXPECT().
 		RemoveParticipantGroupMembers(gomock.Any(), gomock.Any()).
-		Return(errors.New("api error")).
+		Return(nil, errors.New("api error")).
 		MaxTimes(1)
 
 	var b bytes.Buffer
@@ -199,7 +209,7 @@ func TestRemoveCommandFileSkipsBlankLines(t *testing.T) {
 			gomock.Eq(removeSuccessGroupID),
 			gomock.Eq([]string{"part-1", "part-2"}),
 		).
-		Return(nil).
+		Return(removeResponse("remaining-1", "remaining-2"), nil).
 		MaxTimes(1)
 
 	dir := t.TempDir()

--- a/cmd/shared/parse_id_file.go
+++ b/cmd/shared/parse_id_file.go
@@ -1,0 +1,37 @@
+package shared
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ParseIDFile reads a file containing one ID per line.
+// It trims whitespace, skips blank lines, and returns an error
+// if the file is empty or contains no valid entries.
+func ParseIDFile(filePath string) ([]string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file: %w", err)
+	}
+
+	content := strings.TrimRight(string(data), "\n\r ")
+	if content == "" {
+		return nil, fmt.Errorf("file is empty: %s", filePath)
+	}
+
+	var ids []string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		ids = append(ids, line)
+	}
+
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no valid entries found in file: %s", filePath)
+	}
+
+	return ids, nil
+}

--- a/cmd/shared/parse_id_file_test.go
+++ b/cmd/shared/parse_id_file_test.go
@@ -1,0 +1,83 @@
+package shared
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseIDFileReturnsIDs(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "ids.csv")
+	if err := os.WriteFile(filePath, []byte("id-1\nid-2\nid-3\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	ids, err := ParseIDFile(filePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"id-1", "id-2", "id-3"}
+	if len(ids) != len(expected) {
+		t.Fatalf("expected %d ids, got %d", len(expected), len(ids))
+	}
+	for i, id := range ids {
+		if id != expected[i] {
+			t.Errorf("expected ids[%d] = %q, got %q", i, expected[i], id)
+		}
+	}
+}
+
+func TestParseIDFileSkipsBlankLines(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "ids.csv")
+	if err := os.WriteFile(filePath, []byte("id-1\n\n  \nid-2\n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	ids, err := ParseIDFile(filePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 ids, got %d: %v", len(ids), ids)
+	}
+}
+
+func TestParseIDFileErrorsOnEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "empty.csv")
+	if err := os.WriteFile(filePath, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	_, err := ParseIDFile(filePath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "file is empty: "+filePath {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseIDFileErrorsOnMissingFile(t *testing.T) {
+	_, err := ParseIDFile("/nonexistent/path/file.csv")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestParseIDFileErrorsOnWhitespaceOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "whitespace.csv")
+	if err := os.WriteFile(filePath, []byte("   \n  \n"), 0600); err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	_, err := ParseIDFile(filePath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/cmd/submission/bulk_approve.go
+++ b/cmd/submission/bulk_approve.go
@@ -3,10 +3,9 @@ package submission
 import (
 	"fmt"
 	"io"
-	"os"
-	"strings"
 
 	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +72,7 @@ func bulkApproveSubmissions(c client.API, opts BulkApproveOptions, w io.Writer) 
 	}
 
 	if hasFile {
-		ids, err := parseIDFile(opts.File)
+		ids, err := shared.ParseIDFile(opts.File)
 		if err != nil {
 			return err
 		}
@@ -115,31 +114,4 @@ func bulkApproveSubmissions(c client.API, opts BulkApproveOptions, w io.Writer) 
 	fmt.Fprintln(w, "The request to bulk approve has been made successfully.")
 
 	return nil
-}
-
-func parseIDFile(filePath string) ([]string, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read file: %w", err)
-	}
-
-	content := strings.TrimRight(string(data), "\n\r ")
-	if content == "" {
-		return nil, fmt.Errorf("file is empty: %s", filePath)
-	}
-
-	var ids []string
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		ids = append(ids, line)
-	}
-
-	if len(ids) == 0 {
-		return nil, fmt.Errorf("no valid entries found in file: %s", filePath)
-	}
-
-	return ids, nil
 }

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -902,11 +902,12 @@ func (mr *MockAPIMockRecorder) PayBonusPayments(id interface{}) *gomock.Call {
 }
 
 // RemoveParticipantGroupMembers mocks base method.
-func (m *MockAPI) RemoveParticipantGroupMembers(groupID string, participantIDs []string) error {
+func (m *MockAPI) RemoveParticipantGroupMembers(groupID string, participantIDs []string) (*client.ViewParticipantGroupResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveParticipantGroupMembers", groupID, participantIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*client.ViewParticipantGroupResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoveParticipantGroupMembers indicates an expected call of RemoveParticipantGroupMembers.

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -901,6 +901,20 @@ func (mr *MockAPIMockRecorder) PayBonusPayments(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PayBonusPayments", reflect.TypeOf((*MockAPI)(nil).PayBonusPayments), id)
 }
 
+// RemoveParticipantGroupMembers mocks base method.
+func (m *MockAPI) RemoveParticipantGroupMembers(groupID string, participantIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveParticipantGroupMembers", groupID, participantIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveParticipantGroupMembers indicates an expected call of RemoveParticipantGroupMembers.
+func (mr *MockAPIMockRecorder) RemoveParticipantGroupMembers(groupID, participantIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveParticipantGroupMembers", reflect.TypeOf((*MockAPI)(nil).RemoveParticipantGroupMembers), groupID, participantIDs)
+}
+
 // RequestSubmissionReturn mocks base method.
 func (m *MockAPI) RequestSubmissionReturn(ID string, reasons []string) (*client.RequestSubmissionReturnResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

  - Adds `prolific participant remove <group-id>` command to remove one or more participants from a participant group
  - Supports inline IDs (`-p <id>` repeatable) and file-based bulk input (`-f participants.csv`, one ID per line)
  - Extracts shared `ParseIDFile` utility to `cmd/shared/` (previously duplicated in `cmd/submission/bulk_approve.go`)
  - API: `DELETE /api/v1/participant-groups/{id}/participants/` with `{"participant_ids": [...]}`

  ## Test plan

  - [x] `TestRemoveCommandRemovesByInlineIDs` — success path with `-p` flags
  - [x] `TestRemoveCommandRemovesByFile` — success path with `--file`
  - [x] `TestRemoveCommandFileSkipsBlankLines` — blank lines in file are ignored
  - [x] `TestRemoveCommandErrorsIfNoParticipants` — error when no IDs provided
  - [x] `TestRemoveCommandErrorsIfFileAndInlineIDs` — error when `--file` and `--participant-id` are combined
  - [x] `TestRemoveCommandReturnsErrorIfRemoveFails` — API error propagation
  - [x] `TestParseIDFile*` — 5 unit tests for the shared file parsing utility (empty file, missing file, blank lines, whitespace-only, valid)
  - [x] CLI smoke tested: validation errors and API error response verified against a real group