### PR TITLE
feat(DCP-2590): Add aitaskbuilder batch update command [run-release]

### DIFF
--- a/.github/workflows/changelog-gate.yml
+++ b/.github/workflows/changelog-gate.yml
@@ -36,7 +36,7 @@ jobs:
             echo "PR title does not include [run-release]; check passed."
             exit 0
           fi
-          if ! gh pr view "${PR_NUMBER}" --json files -q '.files[].path' | grep -Fxq 'CHANGELOG.md'; then
+          if ! gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" --json files -q '.files[].path' | grep -Fxq 'CHANGELOG.md'; then
             echo "::error::PR title includes [run-release] but CHANGELOG.md is not modified in this PR. Run \`make changelog VERSION=x.y.z\` (or edit CHANGELOG.md) and push before merging."
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,30 +11,26 @@
 - Add aitaskbuilder batch export command
 - Add aitaskbuilder batch update command
 
-### Study
-
-- Unified output format flags
-- Move study ui renderer to ./cmd
-- Add study submission-counts command
-- Add demographic-export and test-study CLI commands
-- Add status code check and improve error handling for study commands
-- Align demographic-export and test-study with API docs
-
 ### Collections
 
 - Update collection rendering
 - Ensure that workspace options default to viper config
 - Move collection renderers to /cmd
 
-### Workspaces
+### Core
 
-- Add workspace balance command
+- Add submissions TUI list view
+- Add invitations support
+- Add interactive drill-down to submission-counts command
+- Make workspace required on hook create
+- Add participant group create command
+- Add researcher create-participant command
 
-### Submissions
+### Filters
 
-- Update submission rendering
-- Add submission transition and bulk-approve commands
-- Add --file flag to submission bulk-approve command
+- Move filter view to ./cmd/filters
+- Add filter-set create command
+- Use dedicated request model and fix selected_range serialization
 
 ### Participant Groups
 
@@ -47,25 +43,32 @@
 - Add create-secret command
 - Add hook subscription delete command
 
-### Filters
+### Study
 
-- Move filter view to ./cmd/filters
-- Add filter-set create command
-- Use dedicated request model and fix selected_range serialization
+- Unified output format flags
+- Move study ui renderer to ./cmd
+- Add study submission-counts command
+- Add demographic-export and test-study CLI commands
+- Add status code check and improve error handling for study commands
+- Align demographic-export and test-study with API docs
 
-### Core
+### Submissions
 
-- Add submissions TUI list view
-- Add invitations support
-- Add interactive drill-down to submission-counts command
-- Make workspace required on hook create
-- Add participant group create command
-- Add survey commands (list, view, create, delete)
+- Update submission rendering
+- Add submission transition and bulk-approve commands
+- Add --file flag to submission bulk-approve command
+
+### Survey
+
+- Add survey list command
+- Add survey view command
+- Add survey create command
+- Add survey delete command
 - Add interactive and JSON output modes to survey list
-- Check status code on CreateHookSecret
-- Add researcher create-participant command
-- Handle 204 response for survey delete and add example template
-- Include response body in status error and simplify error wrapping
+
+### Workspaces
+
+- Add workspace balance command
 
 ## 0.0.66
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 1.0.0
+
+### AI Task Builder
+
+- Add aitaskbuilder batch export command
+- Add aitaskbuilder batch update command
+
+### Study
+
+- Unified output format flags
+- Move study ui renderer to ./cmd
+- Add study submission-counts command
+- Add demographic-export and test-study CLI commands
+- Add status code check and improve error handling for study commands
+- Align demographic-export and test-study with API docs
+
+### Collections
+
+- Update collection rendering
+- Ensure that workspace options default to viper config
+- Move collection renderers to /cmd
+
+### Workspaces
+
+- Add workspace balance command
+
+### Submissions
+
+- Update submission rendering
+- Add submission transition and bulk-approve commands
+- Add --file flag to submission bulk-approve command
+
+### Participant Groups
+
+- Add participant group remove command with bulk and file support
+- Address code review feedback
+
+### Hooks
+
+- Add hook create command
+- Add create-secret command
+- Add hook subscription delete command
+
+### Filters
+
+- Move filter view to ./cmd/filters
+- Add filter-set create command
+- Use dedicated request model and fix selected_range serialization
+
+### Core
+
+- Add submissions TUI list view
+- Add invitations support
+- Add interactive drill-down to submission-counts command
+- Make workspace required on hook create
+- Add participant group create command
+- Add survey commands (list, view, create, delete)
+- Add interactive and JSON output modes to survey list
+- Check status code on CreateHookSecret
+- Add researcher create-participant command
+- Handle 204 response for survey delete and add example template
+- Include response body in status error and simplify error wrapping
+
 ## 0.0.66
 
 ### Templates

--- a/client/client.go
+++ b/client/client.go
@@ -110,6 +110,7 @@ type API interface {
 	CreateAITaskBuilderDataset(workspaceID string, payload CreateAITaskBuilderDatasetPayload) (*CreateAITaskBuilderDatasetResponse, error)
 	CreateAITaskBuilderCollection(payload model.CreateAITaskBuilderCollection) (*CreateAITaskBuilderCollectionResponse, error)
 	GetAITaskBuilderBatch(batchID string) (*GetAITaskBuilderBatchResponse, error)
+	UpdateAITaskBuilderBatch(params UpdateBatchParams) (*UpdateAITaskBuilderBatchResponse, error)
 	GetAITaskBuilderBatchStatus(batchID string) (*GetAITaskBuilderBatchStatusResponse, error)
 	GetAITaskBuilderBatches(workspaceID string) (*GetAITaskBuilderBatchesResponse, error)
 	GetAITaskBuilderResponses(batchID string) (*GetAITaskBuilderResponsesResponse, error)
@@ -1146,6 +1147,37 @@ func (c *Client) PayBonusPayments(id string) error {
 	}
 
 	return nil
+}
+
+// UpdateAITaskBuilderBatch will update an AI Task Builder batch.
+func (c *Client) UpdateAITaskBuilderBatch(params UpdateBatchParams) (*UpdateAITaskBuilderBatchResponse, error) {
+	var response UpdateAITaskBuilderBatchResponse
+
+	payload := UpdateAITaskBuilderBatchPayload{
+		Name:      params.Name,
+		DatasetID: params.DatasetID,
+	}
+
+	if params.TaskName != "" || params.TaskIntroduction != "" || params.TaskSteps != "" {
+		payload.TaskDetails = &TaskDetails{
+			TaskName:         params.TaskName,
+			TaskIntroduction: params.TaskIntroduction,
+			TaskSteps:        params.TaskSteps,
+		}
+	}
+
+	url := fmt.Sprintf("/api/v1/data-collection/batches/%s", params.BatchID)
+	httpResponse, err := c.Execute(http.MethodPatch, url, payload, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	if httpResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResponse.Body)
+		return nil, fmt.Errorf("unable to update batch: %v", string(body))
+	}
+
+	return &response, nil
 }
 
 // GetAITaskBuilderBatch will return details of an AI Task Builder batch.

--- a/client/client.go
+++ b/client/client.go
@@ -1154,16 +1154,9 @@ func (c *Client) UpdateAITaskBuilderBatch(params UpdateBatchParams) (*UpdateAITa
 	var response UpdateAITaskBuilderBatchResponse
 
 	payload := UpdateAITaskBuilderBatchPayload{
-		Name:      params.Name,
-		DatasetID: params.DatasetID,
-	}
-
-	if params.TaskName != "" || params.TaskIntroduction != "" || params.TaskSteps != "" {
-		payload.TaskDetails = &TaskDetails{
-			TaskName:         params.TaskName,
-			TaskIntroduction: params.TaskIntroduction,
-			TaskSteps:        params.TaskSteps,
-		}
+		Name:        params.Name,
+		DatasetID:   params.DatasetID,
+		TaskDetails: params.TaskDetails,
 	}
 
 	url := fmt.Sprintf("/api/v1/data-collection/batches/%s", params.BatchID)

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -93,12 +93,10 @@ type CreateBatchParams struct {
 
 // UpdateBatchParams represents the parameters for updating an AI Task Builder batch.
 type UpdateBatchParams struct {
-	BatchID          string
-	Name             string
-	DatasetID        string
-	TaskName         string
-	TaskIntroduction string
-	TaskSteps        string
+	BatchID     string
+	Name        string
+	DatasetID   string
+	TaskDetails *TaskDetails // nil means task details will not be updated
 }
 
 // UpdateAITaskBuilderBatchPayload represents the JSON payload for updating an AI Task Builder batch.

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -91,6 +91,23 @@ type CreateBatchParams struct {
 	TaskSteps        string `json:"task_steps"`
 }
 
+// UpdateBatchParams represents the parameters for updating an AI Task Builder batch.
+type UpdateBatchParams struct {
+	BatchID          string
+	Name             string
+	DatasetID        string
+	TaskName         string
+	TaskIntroduction string
+	TaskSteps        string
+}
+
+// UpdateAITaskBuilderBatchPayload represents the JSON payload for updating an AI Task Builder batch.
+type UpdateAITaskBuilderBatchPayload struct {
+	Name        string       `json:"name,omitempty"`
+	DatasetID   string       `json:"dataset_id,omitempty"`
+	TaskDetails *TaskDetails `json:"task_details,omitempty"`
+}
+
 // TaskDetails represents the task configuration details for batch creation
 type TaskDetails struct {
 	TaskName         string `json:"task_name"`

--- a/client/responses.go
+++ b/client/responses.go
@@ -237,6 +237,11 @@ type GetAITaskBuilderBatchResponse struct {
 	model.AITaskBuilderBatch
 }
 
+// UpdateAITaskBuilderBatchResponse is the response for the update AI Task Builder batch endpoint.
+type UpdateAITaskBuilderBatchResponse struct {
+	model.AITaskBuilderBatch
+}
+
 // GetAITaskBuilderBatchStatusResponse is the response for the get AI Task Builder get batch status endpoint.
 type GetAITaskBuilderBatchStatusResponse struct {
 	model.AITaskBuilderBatchStatus

--- a/cmd/aitaskbuilder/batch_create_test.go
+++ b/cmd/aitaskbuilder/batch_create_test.go
@@ -144,7 +144,7 @@ func TestNewBatchCreateCommandAPIError(t *testing.T) {
 		t.Fatal("expected error; got nil")
 	}
 
-	expectedError := "error: API error"
+	expectedError := apiError
 	if err.Error() != expectedError {
 		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
 	}

--- a/cmd/aitaskbuilder/batch_setup_test.go
+++ b/cmd/aitaskbuilder/batch_setup_test.go
@@ -129,7 +129,7 @@ func TestNewBatchSetupCommandAPIError(t *testing.T) {
 		t.Fatal("expected error; got nil")
 	}
 
-	expectedError := "error: API error"
+	expectedError := apiError
 	if err.Error() != expectedError {
 		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
 	}

--- a/cmd/aitaskbuilder/batch_update.go
+++ b/cmd/aitaskbuilder/batch_update.go
@@ -95,31 +95,35 @@ func updateAITaskBuilderBatch(c client.API, opts BatchUpdateOptions, w io.Writer
 
 	if anyTaskDetailChanged {
 		if allTaskDetailsChanged {
-			params.TaskName = opts.TaskName
-			params.TaskIntroduction = opts.TaskIntroduction
-			params.TaskSteps = opts.TaskSteps
+			params.TaskDetails = &client.TaskDetails{
+				TaskName:         opts.TaskName,
+				TaskIntroduction: opts.TaskIntroduction,
+				TaskSteps:        opts.TaskSteps,
+			}
 		} else {
 			existing, err := c.GetAITaskBuilderBatch(opts.BatchID)
 			if err != nil {
 				return err
 			}
 
+			taskName := existing.TaskDetails.TaskName
+			taskIntroduction := existing.TaskDetails.TaskIntroduction
+			taskSteps := existing.TaskDetails.TaskSteps
+
 			if opts.TaskNameChanged {
-				params.TaskName = opts.TaskName
-			} else {
-				params.TaskName = existing.TaskDetails.TaskName
+				taskName = opts.TaskName
 			}
-
 			if opts.TaskIntroductionChanged {
-				params.TaskIntroduction = opts.TaskIntroduction
-			} else {
-				params.TaskIntroduction = existing.TaskDetails.TaskIntroduction
+				taskIntroduction = opts.TaskIntroduction
+			}
+			if opts.TaskStepsChanged {
+				taskSteps = opts.TaskSteps
 			}
 
-			if opts.TaskStepsChanged {
-				params.TaskSteps = opts.TaskSteps
-			} else {
-				params.TaskSteps = existing.TaskDetails.TaskSteps
+			params.TaskDetails = &client.TaskDetails{
+				TaskName:         taskName,
+				TaskIntroduction: taskIntroduction,
+				TaskSteps:        taskSteps,
 			}
 		}
 	}

--- a/cmd/aitaskbuilder/batch_update.go
+++ b/cmd/aitaskbuilder/batch_update.go
@@ -1,0 +1,158 @@
+package aitaskbuilder
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+type BatchUpdateOptions struct {
+	Args                    []string
+	BatchID                 string
+	Name                    string
+	DatasetID               string
+	TaskName                string
+	TaskIntroduction        string
+	TaskSteps               string
+	TaskNameChanged         bool
+	TaskIntroductionChanged bool
+	TaskStepsChanged        bool
+}
+
+func NewBatchUpdateCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts BatchUpdateOptions
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a batch",
+		Long: `Update an existing AI Task Builder batch
+
+This command updates a batch's name, dataset, and/or task details. At least one
+field must be provided. Task detail flags can be provided individually — any
+omitted task detail fields will be preserved from the existing batch.`,
+		Example: `
+Update a batch name:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -n "Updated Batch Name"
+
+Update a single task detail field:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 --task-name "New Task Name"
+
+Update all task details:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 --task-name "New Task" --task-introduction "New introduction" --task-steps "1. Step one\n2. Step two"
+
+Update name and dataset:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -n "Updated Name" -d 1234acb09999db4b99bcded1
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+			opts.TaskNameChanged = cmd.Flags().Changed("task-name")
+			opts.TaskIntroductionChanged = cmd.Flags().Changed("task-introduction")
+			opts.TaskStepsChanged = cmd.Flags().Changed("task-steps")
+
+			err := updateAITaskBuilderBatch(client, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.BatchID, "batch-id", "b", "", "Batch ID (required) - The ID of the batch to update.")
+	flags.StringVarP(&opts.Name, "name", "n", "", "Batch name - The new name for the batch.")
+	flags.StringVarP(&opts.DatasetID, "dataset-id", "d", "", "Dataset ID - The ID of the new dataset to link to the batch.")
+	flags.StringVar(&opts.TaskName, "task-name", "", "Task name - The new name of the task.")
+	flags.StringVar(&opts.TaskIntroduction, "task-introduction", "", "Task introduction - The new introduction text for the task.")
+	flags.StringVar(&opts.TaskSteps, "task-steps", "", "Task steps - The new steps for completing the task.")
+
+	_ = cmd.MarkFlagRequired("batch-id")
+
+	return cmd
+}
+
+// updateAITaskBuilderBatch will update an existing AI Task Builder batch
+func updateAITaskBuilderBatch(c client.API, opts BatchUpdateOptions, w io.Writer) error {
+	if opts.BatchID == "" {
+		return errors.New(ErrBatchIDRequired)
+	}
+
+	anyTaskDetailChanged := opts.TaskNameChanged || opts.TaskIntroductionChanged || opts.TaskStepsChanged
+	allTaskDetailsChanged := opts.TaskNameChanged && opts.TaskIntroductionChanged && opts.TaskStepsChanged
+
+	if opts.Name == "" && opts.DatasetID == "" && !anyTaskDetailChanged {
+		return errors.New(ErrAtLeastOneUpdateFieldRequired)
+	}
+
+	params := client.UpdateBatchParams{
+		BatchID:   opts.BatchID,
+		Name:      opts.Name,
+		DatasetID: opts.DatasetID,
+	}
+
+	if anyTaskDetailChanged {
+		if allTaskDetailsChanged {
+			params.TaskName = opts.TaskName
+			params.TaskIntroduction = opts.TaskIntroduction
+			params.TaskSteps = opts.TaskSteps
+		} else {
+			existing, err := c.GetAITaskBuilderBatch(opts.BatchID)
+			if err != nil {
+				return err
+			}
+
+			if opts.TaskNameChanged {
+				params.TaskName = opts.TaskName
+			} else {
+				params.TaskName = existing.TaskDetails.TaskName
+			}
+
+			if opts.TaskIntroductionChanged {
+				params.TaskIntroduction = opts.TaskIntroduction
+			} else {
+				params.TaskIntroduction = existing.TaskDetails.TaskIntroduction
+			}
+
+			if opts.TaskStepsChanged {
+				params.TaskSteps = opts.TaskSteps
+			} else {
+				params.TaskSteps = existing.TaskDetails.TaskSteps
+			}
+		}
+	}
+
+	response, err := c.UpdateAITaskBuilderBatch(params)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "AI Task Builder Batch Updated Successfully:\n")
+	fmt.Fprintf(w, "ID: %s\n", response.ID)
+	fmt.Fprintf(w, "Name: %s\n", response.Name)
+	fmt.Fprintf(w, "Status: %s\n", response.Status)
+	fmt.Fprintf(w, "Total Task Count: %d\n", response.TotalTaskCount)
+	fmt.Fprintf(w, "Total Instruction Count: %d\n", response.TotalInstructionCount)
+	fmt.Fprintf(w, "Workspace ID: %s\n", response.WorkspaceID)
+	fmt.Fprintf(w, "Created By: %s\n", response.CreatedBy)
+	fmt.Fprintf(w, "Created At: %s\n", response.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(w, "Schema Version: %d\n", response.SchemaVersion)
+
+	if len(response.Datasets) > 0 {
+		fmt.Fprintf(w, "Datasets: %d\n", len(response.Datasets))
+		for i, dataset := range response.Datasets {
+			fmt.Fprintf(w, "  Dataset %d: %s (%d datapoints)\n", i+1, dataset.ID, dataset.TotalDatapointCount)
+		}
+	}
+
+	if response.TaskDetails.TaskName != "" {
+		fmt.Fprintf(w, "\nTask Details:\n")
+		fmt.Fprintf(w, "  Name: %s\n", response.TaskDetails.TaskName)
+		fmt.Fprintf(w, "  Introduction: %s\n", response.TaskDetails.TaskIntroduction)
+		fmt.Fprintf(w, "  Steps: %s\n", response.TaskDetails.TaskSteps)
+	}
+
+	return nil
+}

--- a/cmd/aitaskbuilder/batch_update_test.go
+++ b/cmd/aitaskbuilder/batch_update_test.go
@@ -1,0 +1,325 @@
+package aitaskbuilder_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/aitaskbuilder"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+const updateBatchID = "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+
+func TestNewBatchUpdateCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, os.Stdout)
+
+	use := "update"
+	short := "Update a batch"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestNewBatchUpdateCommandUpdatesName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := updateBatchID
+	batchName := "Updated Batch Name"
+
+	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
+	response := &client.UpdateAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:                    batchID,
+			CreatedAt:             createdAt,
+			CreatedBy:             "6139f0d1dc08858054c63b2c",
+			Name:                  batchName,
+			Status:                "UNINITIALISED",
+			TotalTaskCount:        0,
+			TotalInstructionCount: 5,
+			WorkspaceID:           "6745ab669112d10b9b3afb48",
+			SchemaVersion:         3,
+			Datasets:              []model.Dataset{},
+			TaskDetails:           model.TaskDetails{},
+		},
+	}
+
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID: batchID,
+		Name:    batchName,
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", batchID, "--name", batchName})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected error to be nil; got %v", err)
+	}
+
+	writer.Flush()
+
+	expected := fmt.Sprintf("AI Task Builder Batch Updated Successfully:\nID: %s\nName: %s\nStatus: %s\nTotal Task Count: %d\nTotal Instruction Count: %d\nWorkspace ID: %s\nCreated By: %s\nCreated At: %s\nSchema Version: %d\n",
+		response.ID, response.Name, response.Status, response.TotalTaskCount, response.TotalInstructionCount,
+		response.WorkspaceID, response.CreatedBy, "2025-02-27 18:03:59", response.SchemaVersion)
+
+	if b.String() != expected {
+		t.Fatalf("expected output:\n%s\ngot output:\n%s", expected, b.String())
+	}
+}
+
+func TestNewBatchUpdateCommandUpdatesAllTaskDetails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := updateBatchID
+	taskName := "Updated Task"
+	taskIntroduction := "Updated introduction"
+	taskSteps := "1. Updated step"
+
+	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
+	response := &client.UpdateAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:            batchID,
+			CreatedAt:     createdAt,
+			CreatedBy:     "6139f0d1dc08858054c63b2c",
+			Name:          "Existing Name",
+			Status:        "UNINITIALISED",
+			WorkspaceID:   "6745ab669112d10b9b3afb48",
+			SchemaVersion: 3,
+			Datasets:      []model.Dataset{},
+			TaskDetails: model.TaskDetails{
+				TaskName:         taskName,
+				TaskIntroduction: taskIntroduction,
+				TaskSteps:        taskSteps,
+			},
+		},
+	}
+
+	// All three task detail flags provided — no GET call expected
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID:          batchID,
+		TaskName:         taskName,
+		TaskIntroduction: taskIntroduction,
+		TaskSteps:        taskSteps,
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{
+		"--batch-id", batchID,
+		"--task-name", taskName,
+		"--task-introduction", taskIntroduction,
+		"--task-steps", taskSteps,
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected error to be nil; got %v", err)
+	}
+
+	writer.Flush()
+
+	expected := fmt.Sprintf("AI Task Builder Batch Updated Successfully:\nID: %s\nName: %s\nStatus: %s\nTotal Task Count: %d\nTotal Instruction Count: %d\nWorkspace ID: %s\nCreated By: %s\nCreated At: %s\nSchema Version: %d\n\nTask Details:\n  Name: %s\n  Introduction: %s\n  Steps: %s\n",
+		response.ID, response.Name, response.Status, response.TotalTaskCount, response.TotalInstructionCount,
+		response.WorkspaceID, response.CreatedBy, "2025-02-27 18:03:59", response.SchemaVersion,
+		taskName, taskIntroduction, taskSteps)
+
+	if b.String() != expected {
+		t.Fatalf("expected output:\n%s\ngot output:\n%s", expected, b.String())
+	}
+}
+
+func TestNewBatchUpdateCommandMergesPartialTaskDetails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := updateBatchID
+	newTaskName := "Updated Task Name"
+	existingIntroduction := "Existing introduction"
+	existingSteps := "Existing steps"
+
+	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
+
+	existingBatch := &client.GetAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:        batchID,
+			CreatedAt: createdAt,
+			TaskDetails: model.TaskDetails{
+				TaskName:         "Old Task Name",
+				TaskIntroduction: existingIntroduction,
+				TaskSteps:        existingSteps,
+			},
+		},
+	}
+
+	// Partial task details trigger a GET to fetch existing values
+	c.EXPECT().GetAITaskBuilderBatch(batchID).Return(existingBatch, nil)
+
+	updateResponse := &client.UpdateAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:            batchID,
+			CreatedAt:     createdAt,
+			CreatedBy:     "6139f0d1dc08858054c63b2c",
+			Name:          "Existing Name",
+			Status:        "UNINITIALISED",
+			WorkspaceID:   "6745ab669112d10b9b3afb48",
+			SchemaVersion: 3,
+			Datasets:      []model.Dataset{},
+			TaskDetails: model.TaskDetails{
+				TaskName:         newTaskName,
+				TaskIntroduction: existingIntroduction,
+				TaskSteps:        existingSteps,
+			},
+		},
+	}
+
+	// Merged params: new task name + existing introduction and steps
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID:          batchID,
+		TaskName:         newTaskName,
+		TaskIntroduction: existingIntroduction,
+		TaskSteps:        existingSteps,
+	}).Return(updateResponse, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", batchID, "--task-name", newTaskName})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected error to be nil; got %v", err)
+	}
+
+	writer.Flush()
+
+	if b.Len() == 0 {
+		t.Fatal("expected output; got none")
+	}
+}
+
+func TestNewBatchUpdateCommandGetErrorOnPartialTaskDetails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := updateBatchID
+
+	c.EXPECT().GetAITaskBuilderBatch(batchID).Return(nil, errors.New("batch not found"))
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", batchID, "--task-name", "New Task"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+
+	expectedError := "error: batch not found"
+	if err.Error() != expectedError {
+		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
+	}
+}
+
+func TestNewBatchUpdateCommandAPIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	batchID := updateBatchID
+
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID: batchID,
+		Name:    "New Name",
+	}).Return(nil, errors.New("API error"))
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", batchID, "--name", "New Name"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+
+	expectedError := apiError
+	if err.Error() != expectedError {
+		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
+	}
+}
+
+func TestNewBatchUpdateCommandMissingBatchID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--name", "New Name"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+
+	expectedError := `required flag(s) "batch-id" not set`
+	if err.Error() != expectedError {
+		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
+	}
+}
+
+func TestNewBatchUpdateCommandNoFieldsProvided(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", "497f6eca-6276-4993-bfeb-53cbbbba6f08"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+
+	expectedError := "error: " + aitaskbuilder.ErrAtLeastOneUpdateFieldRequired
+	if err.Error() != expectedError {
+		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
+	}
+}

--- a/cmd/aitaskbuilder/batch_update_test.go
+++ b/cmd/aitaskbuilder/batch_update_test.go
@@ -120,10 +120,12 @@ func TestNewBatchUpdateCommandUpdatesAllTaskDetails(t *testing.T) {
 
 	// All three task detail flags provided — no GET call expected
 	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
-		BatchID:          batchID,
-		TaskName:         taskName,
-		TaskIntroduction: taskIntroduction,
-		TaskSteps:        taskSteps,
+		BatchID: batchID,
+		TaskDetails: &client.TaskDetails{
+			TaskName:         taskName,
+			TaskIntroduction: taskIntroduction,
+			TaskSteps:        taskSteps,
+		},
 	}).Return(response, nil)
 
 	var b bytes.Buffer
@@ -201,10 +203,12 @@ func TestNewBatchUpdateCommandMergesPartialTaskDetails(t *testing.T) {
 
 	// Merged params: new task name + existing introduction and steps
 	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
-		BatchID:          batchID,
-		TaskName:         newTaskName,
-		TaskIntroduction: existingIntroduction,
-		TaskSteps:        existingSteps,
+		BatchID: batchID,
+		TaskDetails: &client.TaskDetails{
+			TaskName:         newTaskName,
+			TaskIntroduction: existingIntroduction,
+			TaskSteps:        existingSteps,
+		},
 	}).Return(updateResponse, nil)
 
 	var b bytes.Buffer

--- a/cmd/aitaskbuilder/batches.go
+++ b/cmd/aitaskbuilder/batches.go
@@ -17,6 +17,7 @@ func NewBatchesCommand(client client.API, w io.Writer) *cobra.Command {
 
 	cmd.AddCommand(
 		NewBatchCreateCommand(client, w),
+		NewBatchUpdateCommand(client, w),
 		NewBatchExportCommand(client, w),
 		NewBatchInstructionsCommand(client, w),
 		NewBatchSetupCommand(client, w),

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -15,4 +15,5 @@ const (
 	ErrTaskStepsRequired             = "task steps is required"
 	ErrTasksPerGroupMinimum          = "tasks per group must be at least 1"
 	ErrWorkspaceIDRequired           = "workspace ID is required"
+	ErrAtLeastOneUpdateFieldRequired = "at least one of --name, --dataset-id, or task detail flags must be provided"
 )

--- a/cmd/aitaskbuilder/datasets_test.go
+++ b/cmd/aitaskbuilder/datasets_test.go
@@ -12,6 +12,7 @@ const (
 	createCommandUse       = "create"
 	uploadCommandUse       = "upload"
 	workspaceNotFoundError = "workspace not found"
+	apiError               = "error: API error"
 )
 
 func TestNewDatasetsCommand(t *testing.T) {

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -497,21 +497,6 @@ func (mr *MockAPIMockRecorder) GetBatchExportStatus(batchID, exportID interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBatchExportStatus", reflect.TypeOf((*MockAPI)(nil).GetBatchExportStatus), batchID, exportID)
 }
 
-// InitiateBatchExport mocks base method.
-func (m *MockAPI) InitiateBatchExport(batchID string) (*client.BatchExportResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitiateBatchExport", batchID)
-	ret0, _ := ret[0].(*client.BatchExportResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// InitiateBatchExport indicates an expected call of InitiateBatchExport.
-func (mr *MockAPIMockRecorder) InitiateBatchExport(batchID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitiateBatchExport", reflect.TypeOf((*MockAPI)(nil).InitiateBatchExport), batchID)
-}
-
 // GetCampaigns mocks base method.
 func (m *MockAPI) GetCampaigns(workspaceID string, limit, offset int) (*client.ListCampaignsResponse, error) {
 	m.ctrl.T.Helper()
@@ -917,6 +902,21 @@ func (mr *MockAPIMockRecorder) GetWorkspaces(limit, offset interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaces", reflect.TypeOf((*MockAPI)(nil).GetWorkspaces), limit, offset)
 }
 
+// InitiateBatchExport mocks base method.
+func (m *MockAPI) InitiateBatchExport(batchID string) (*client.BatchExportResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitiateBatchExport", batchID)
+	ret0, _ := ret[0].(*client.BatchExportResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InitiateBatchExport indicates an expected call of InitiateBatchExport.
+func (mr *MockAPIMockRecorder) InitiateBatchExport(batchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitiateBatchExport", reflect.TypeOf((*MockAPI)(nil).InitiateBatchExport), batchID)
+}
+
 // InitiateCollectionExport mocks base method.
 func (m *MockAPI) InitiateCollectionExport(collectionID string) (*client.CollectionExportResponse, error) {
 	m.ctrl.T.Helper()
@@ -1077,6 +1077,21 @@ func (m *MockAPI) TransitionSubmission(ID string, payload client.TransitionSubmi
 func (mr *MockAPIMockRecorder) TransitionSubmission(ID, payload interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransitionSubmission", reflect.TypeOf((*MockAPI)(nil).TransitionSubmission), ID, payload)
+}
+
+// UpdateAITaskBuilderBatch mocks base method.
+func (m *MockAPI) UpdateAITaskBuilderBatch(params client.UpdateBatchParams) (*client.UpdateAITaskBuilderBatchResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAITaskBuilderBatch", params)
+	ret0, _ := ret[0].(*client.UpdateAITaskBuilderBatchResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAITaskBuilderBatch indicates an expected call of UpdateAITaskBuilderBatch.
+func (mr *MockAPIMockRecorder) UpdateAITaskBuilderBatch(params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAITaskBuilderBatch", reflect.TypeOf((*MockAPI)(nil).UpdateAITaskBuilderBatch), params)
 }
 
 // UpdateCollection mocks base method.


### PR DESCRIPTION
## Summary

Implements the `prolific aitaskbuilder batch update` command, backed by a new `PATCH /api/v1/data-collection/batches/{batch_id}` client method.

- Adds `--name`, `--dataset-id`, `--task-name`, `--task-introduction`, and `--task-steps` flags (all optional; at least one required)
- Partial task detail updates are supported - if only some task detail flags are provided, the CLI fetches the existing batch and merges the missing values before sending the request
