### PR TITLE
docs(DCP-2583): update docs and changelog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,5 +10,6 @@ When asked to create a release:
 - Increment the version in `CHANGELOG.md` and define a new heading.
 - Follow the existing format in `CHANGELOG.md`:
   - `## next` for the upcoming version.
-  - `## x.y.z` for previous versions, with bullet points for changes.
+  - `## x.y.z` for previous versions, with bullet points for changes (headings are bare semver, **no** `v` prefix).
   - Do not include dates — version numbers only.
+- Git tags and GitHub Release names use a `v` prefix (`v1.0.1`), matching what `create-release.yml` publishes; do not name releases with a bare version string.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,10 +6,10 @@
 
 When asked to create a release:
 
-- Use the last git tag and summarise the commits since.
-- Increment the version in `CHANGELOG.md` and define a new heading.
+- Run `make changelog VERSION=x.y.z` (with `git-cliff` installed) so grouped notes are generated; do not hand-edit the full release section unless adding content under `## next` before running the command.
+- Open a PR with the updated `CHANGELOG.md` and add the **`release`** label. Merging to `main` triggers `create-release.yml`, which only creates the tag, GitHub Release, and binaries when that merged PR has the `release` label.
 - Follow the existing format in `CHANGELOG.md`:
-  - `## next` for the upcoming version.
-  - `## x.y.z` for previous versions, with bullet points for changes (headings are bare semver, **no** `v` prefix).
+  - `## next` for hand-written notes to merge into the next run of `make changelog`.
+  - `## x.y.z` for released versions, with bullet points for changes (headings are bare semver, **no** `v` prefix).
   - Do not include dates — version numbers only.
 - Git tags and GitHub Release names use a `v` prefix (`v1.0.1`), matching what `create-release.yml` publishes; do not name releases with a bare version string.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ This uses `git-cliff` (must be installed separately: `brew install git-cliff`) p
 
 1. Review and commit the updated `CHANGELOG.md`
 2. Get the PR merged to `main`
-3. Create a GitHub Release with the matching tag (`vx.y.z`) — the `release.yml` workflow builds and uploads binaries automatically
+3. CI creates the GitHub Release with tag and title `vx.y.z` (e.g. `v1.0.1`, never a bare `1.0.1`) — the `release.yml` workflow builds and uploads binaries automatically
 
 To include hand-written notes in the next release, add them under `## next` in `CHANGELOG.md` before running `make changelog` — they will be merged in automatically.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,8 +239,8 @@ make changelog VERSION=x.y.z   # Generate grouped CHANGELOG.md entry for the rel
 This uses `git-cliff` (must be installed separately: `brew install git-cliff`) plus a custom Go script in `scripts/changelog/` that groups entries by subcommand area. After running:
 
 1. Review and commit the updated `CHANGELOG.md`
-2. Get the PR merged to `main`
-3. CI creates the GitHub Release with tag and title `vx.y.z` (e.g. `v1.0.1`, never a bare `1.0.1`) — the `release.yml` workflow builds and uploads binaries automatically
+2. Open a PR, add the `release` label, and merge to `main`
+3. The `create-release.yml` workflow runs on the push to `main`. It creates the GitHub Release with tag and title `vx.y.z` (e.g. `v1.0.1`, never a bare `1.0.1`) and uploads binaries **only** when the merged PR had the `release` label; ordinary pushes to `main` do not release
 
 To include hand-written notes in the next release, add them under `## next` in `CHANGELOG.md` before running `make changelog` — they will be merged in automatically.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 1.0.1
+
+### Workspaces
+
+- Allow users to utilise active workspace on balance command
+
 ## 1.0.0
 
 ### AI Task Builder

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -431,11 +431,11 @@ Enforces [Conventional Commits](https://www.conventionalcommits.org/) format on 
 
 1. Run `make changelog VERSION=0.0.60` to generate grouped release notes
 2. Create a PR with the updated `CHANGELOG.md` and apply the `release` label
-3. Get the PR reviewed and merge to `main` — CI automatically creates the git tag, GitHub Release, and uploads binaries
+3. Get the PR reviewed and merge to `main` — the `create-release.yml` workflow runs on that push and creates the git tag, GitHub Release, and uploads binaries **only** when the merged PR is labeled `release` (pushes to `main` without that label do not trigger a release)
 
 One CI gate guards the PR:
 
-- `**changelog-gate.yml`\*\* — fails if the `release` label is present but `CHANGELOG.md` is not modified
+- **`changelog-gate.yml`** — fails if the `release` label is present but `CHANGELOG.md` is not modified
 
 ## Changelog Conventions
 
@@ -504,11 +504,15 @@ Runs on pull request events. Fails if the PR has the `release` label but `CHANGE
 
 ### `create-release.yml`
 
-Runs when a PR with the `release` label is merged to `main`. Uses `go run ./scripts/changelog extract-version` to read the version from the top-most `## x.y.z` section in `CHANGELOG.md`, then:
+Runs on every **push to `main`**. A first job (`should-release`) inspects the commits in that push and uses the GitHub API to see whether any of them is linked to a merged PR that has the `release` label. If not, the rest of the workflow is skipped.
 
-1. Creates and pushes a `vx.y.z` annotated tag
-2. Creates a GitHub Release named `vx.y.z` (tag and release title both use the `v` prefix) with the matching changelog entry as notes
-3. Builds binaries for darwin, linux, windows, and freebsd and uploads them to the release
+When the label is present, `finalize-release` uses `go run ./scripts/changelog extract-version` to read the version from the top-most `## x.y.z` section in `CHANGELOG.md`, then:
+
+1. Writes release notes with `go run ./scripts/changelog extract --section <version>` into `RELEASE_NOTES.md`
+2. Creates and pushes a `vx.y.z` annotated tag
+3. Creates a GitHub Release named `vx.y.z` (tag and release title both use the `v` prefix) with those notes
+
+The `build` job then checks out that tag, runs `make static-named` for each target platform, and uploads the binaries to the same GitHub Release.
 
 ## Common Patterns
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -435,7 +435,7 @@ Enforces [Conventional Commits](https://www.conventionalcommits.org/) format on 
 
 One CI gate guards the PR:
 
-- `**changelog-gate.yml`** — fails if the `release` label is present but `CHANGELOG.md` is not modified
+- `**changelog-gate.yml`\*\* — fails if the `release` label is present but `CHANGELOG.md` is not modified
 
 ## Changelog Conventions
 
@@ -445,6 +445,7 @@ Changelog entries are generated from conventional commits by [git-cliff](https:/
 
 This project uses [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). While the project is pre-1.0, all releases use `0.0.x`.
 
+**Release naming:** Git tags and GitHub Releases must use a leading `v` (e.g. `v1.0.1`), not a bare version string (`1.0.1`). The automated release workflow creates both the tag and the release title as `vx.y.z`. `CHANGELOG.md` headings stay as bare semver (`## 1.0.1`) — that is intentional. When you run `make changelog`, pass `VERSION` **without** the `v` (e.g. `VERSION=1.0.1`); tooling adds the prefix for tags and releases.
 
 | Change                                                                       | Version bump                | Example                                     |
 | ---------------------------------------------------------------------------- | --------------------------- | ------------------------------------------- |
@@ -452,10 +453,9 @@ This project uses [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH
 | New command or flag                                                          | `PATCH`                     | Adding `study delete`                       |
 | Bug fix, docs, refactor, CI                                                  | `PATCH`                     | Fixing a nil-pointer crash                  |
 
-
 **Pre-1.0 note:** `MAJOR` stays at `0` until the API and command surface are considered stable. `MINOR` bumps signal breaking changes for the duration of `0.x`.
 
-The version is passed to `make changelog VERSION=x.y.z` — there is no automated bump calculation; the release author decides based on the table above.
+The version is passed to `make changelog VERSION=x.y.z` (numeric only, no `v` prefix) — there is no automated bump calculation; the release author decides based on the table above.
 
 ### Manual release notes
 
@@ -507,7 +507,7 @@ Runs on pull request events. Fails if the PR has the `release` label but `CHANGE
 Runs when a PR with the `release` label is merged to `main`. Uses `go run ./scripts/changelog extract-version` to read the version from the top-most `## x.y.z` section in `CHANGELOG.md`, then:
 
 1. Creates and pushes a `vx.y.z` annotated tag
-2. Creates a GitHub Release with the matching changelog entry as notes
+2. Creates a GitHub Release named `vx.y.z` (tag and release title both use the `v` prefix) with the matching changelog entry as notes
 3. Builds binaries for darwin, linux, windows, and freebsd and uploads them to the release
 
 ## Common Patterns
@@ -516,9 +516,11 @@ Runs when a PR with the `release` label is merged to `main`. Uses `go run ./scri
 
 1. Create package under `cmd/<resource>/`
 2. Implement command function(s) following pattern:
-  ```go
-   func NewXCommand(client client.API, w io.Writer) *cobra.Command
-  ```
+
+```go
+ func NewXCommand(client client.API, w io.Writer) *cobra.Command
+```
+
 3. Add tests in `<command>_test.go`
 4. Register in `cmd/root.go:65-80`
 5. Update `CHANGELOG.md`
@@ -640,7 +642,6 @@ Uses `github.com/pkg/browser` package.
 
 ## Quick Reference
 
-
 | Task                    | Command                                 |
 | ----------------------- | --------------------------------------- |
 | Install deps & setup    | `make install`                          |
@@ -654,7 +655,6 @@ Uses `github.com/pkg/browser` package.
 | List studies            | `./prolific study list`                 |
 | Create study            | `./prolific study create -t <template>` |
 
-
 ## Notes for AI Agents
 
 - **Always run tests after changes**: `make test`
@@ -666,4 +666,3 @@ Uses `github.com/pkg/browser` package.
 - **Use dependency injection** - pass `client.API` and `io.Writer` to commands
 - **Consider interactive vs non-interactive** modes for list commands
 - **Look at examples** in `docs/examples/` for study template structure
-

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ static-all: clean install static test
 .PHONY: changelog
 changelog: ## Generate grouped changelog for a release (Usage: make changelog VERSION=0.0.61 — numeric only; tag/release will be v0.0.61)
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make changelog VERSION=0.0.61 (published tag is v0.0.61)"; exit 1; fi
+	@go run ./scripts/changelog validate-version "$(VERSION)"
 	@command -v git-cliff >/dev/null 2>&1 || { \
  		echo "Error: git-cliff is required to generate the changelog but was not found in PATH."; \
  		echo "Please install git-cliff (run `brew install git-cliff` or see https://git-cliff.org/docs/installation/) and try again."; \

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ all: clean install build test
 static-all: clean install static test
 
 .PHONY: changelog
-changelog: ## Generate grouped changelog for a release (Usage: make changelog VERSION=0.0.61)
-	@if [ -z "$(VERSION)" ]; then echo "Usage: make changelog VERSION=0.0.61"; exit 1; fi
+changelog: ## Generate grouped changelog for a release (Usage: make changelog VERSION=0.0.61 — numeric only; tag/release will be v0.0.61)
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make changelog VERSION=0.0.61 (published tag is v0.0.61)"; exit 1; fi
 	@command -v git-cliff >/dev/null 2>&1 || { \
  		echo "Error: git-cliff is required to generate the changelog but was not found in PATH."; \
  		echo "Please install git-cliff (run `brew install git-cliff` or see https://git-cliff.org/docs/installation/) and try again."; \

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Once the PR is approved and merged to `main`, CI automatically:
 
 1. Extracts the version from the latest `## x.y.z` section in `CHANGELOG.md`
 2. Creates and pushes a `vx.y.z` git tag
-3. Creates a GitHub Release with the changelog entry as release notes
+3. Creates a GitHub Release titled `vx.y.z` (always use the `v` prefix for tags and release names, e.g. `v1.0.1`, not `1.0.1`) with the changelog entry as release notes
 4. Builds binaries for multiple platforms (darwin, linux, windows, freebsd) and uploads them to the release
 
 Users can then download binaries from the release page or use `go install`.

--- a/README.md
+++ b/README.md
@@ -225,11 +225,13 @@ One CI gate will validate the PR:
 
 ### 3. Merge to trigger the release
 
-Once the PR is approved and merged to `main`, CI automatically:
+Merging the PR to `main` triggers `.github/workflows/create-release.yml` on that push. The workflow only performs a release when the **merged PR has the `release` label** (it checks linked PRs for that label); other pushes to `main` do not create tags or releases.
 
-1. Extracts the version from the latest `## x.y.z` section in `CHANGELOG.md`
+When a release runs, it automatically:
+
+1. Extracts the version from the top-most `## x.y.z` section in `CHANGELOG.md`
 2. Creates and pushes a `vx.y.z` git tag
-3. Creates a GitHub Release titled `vx.y.z` (always use the `v` prefix for tags and release names, e.g. `v1.0.1`, not `1.0.1`) with the changelog entry as release notes
+3. Creates a GitHub Release titled `vx.y.z` (always use the `v` prefix for tags and release names, e.g. `v1.0.1`, not `1.0.1`) with the matching changelog section as release notes
 4. Builds binaries for multiple platforms (darwin, linux, windows, freebsd) and uploads them to the release
 
 Users can then download binaries from the release page or use `go install`.

--- a/scripts/changelog/main.go
+++ b/scripts/changelog/main.go
@@ -5,6 +5,7 @@
 //
 //	go run ./scripts/changelog extract --section next --strip-comments
 //	go run ./scripts/changelog extract-version
+//	go run ./scripts/changelog validate-version 0.1.0
 //	go run ./scripts/changelog merge --manual MANUAL.md --generated CLIFF.md --output MERGED.md
 //	go run ./scripts/changelog update --version 0.1.0 --notes NOTES.md
 package main
@@ -31,7 +32,7 @@ var (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: changelog <extract|extract-version|merge|update|transform> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: changelog <extract|extract-version|validate-version|merge|update|transform> [flags]")
 		os.Exit(1)
 	}
 
@@ -43,6 +44,8 @@ func main() {
 		runExtract()
 	case "extract-version":
 		runExtractVersion()
+	case "validate-version":
+		runValidateVersion()
 	case "merge":
 		runMerge()
 	case "update":
@@ -98,6 +101,25 @@ func runExtract() {
 
 	result := ExtractSection(string(data), *section, *stripComments)
 	fmt.Print(result)
+}
+
+// StrictSemver reports whether s is major.minor.patch with digits only (no v prefix,
+// no pre-release metadata). This must match ExtractReleaseVersion and the changelog
+// release workflow.
+func StrictSemver(s string) bool {
+	return reStrictSemver.MatchString(strings.TrimSpace(s))
+}
+
+func runValidateVersion() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "validate-version: version argument required (strict x.y.z, no v prefix)")
+		os.Exit(1)
+	}
+	v := strings.TrimSpace(os.Args[1])
+	if !StrictSemver(v) {
+		fmt.Fprintf(os.Stderr, "validate-version: %q is invalid — use strict semver x.y.z with digits only (e.g. 0.0.61, not v0.0.61)\n", v)
+		os.Exit(1)
+	}
 }
 
 func runExtractVersion() {
@@ -173,6 +195,10 @@ func runUpdate() {
 		fmt.Fprintln(os.Stderr, "update: --version is required")
 		os.Exit(1)
 	}
+	if !StrictSemver(*version) {
+		fmt.Fprintf(os.Stderr, "update: --version must be strict x.y.z (digits only, no v prefix), got %q\n", *version)
+		os.Exit(1)
+	}
 	if *notes == "" {
 		fmt.Fprintln(os.Stderr, "update: --notes is required")
 		os.Exit(1)
@@ -239,7 +265,7 @@ func ExtractReleaseVersion(changelog string) (version string, ok bool) {
 		if heading == "next" {
 			continue
 		}
-		if reStrictSemver.MatchString(heading) {
+		if StrictSemver(heading) {
 			return heading, true
 		}
 	}

--- a/scripts/changelog/main_test.go
+++ b/scripts/changelog/main_test.go
@@ -113,6 +113,31 @@ Notes.
 	}
 }
 
+func TestStrictSemver(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid patch", "0.0.61", true},
+		{"valid multi digit", "10.20.30", true},
+		{"v prefix", "v0.0.61", false},
+		{"pre-release", "1.0.0-beta.1", false},
+		{"build metadata", "1.0.0+build", false},
+		{"two components", "1.0", false},
+		{"empty", "", false},
+		{"whitespace padded valid", "  1.2.3  ", true},
+		{"leading zero segment ok", "0.01.2", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StrictSemver(tt.in); got != tt.want {
+				t.Errorf("StrictSemver(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractSection(t *testing.T) {
 	changelog := `# CHANGELOG
 


### PR DESCRIPTION
This pull request refines and enforces the release process, changelog versioning, and automation for the project. It introduces stricter validation for release versions, clarifies documentation around how releases are triggered and named, and improves the supporting tooling and workflow for changelog management. The main focus is to ensure that only strictly formatted semantic versions (e.g., `1.0.1`, not `v1.0.1` or `1.0.1-beta`) are accepted in changelogs and release processes, and that releases are only published when a merged PR is labeled `release`.

**Release process improvements:**

- Updated documentation (`DEVELOPMENT.md`, `.github/copilot-instructions.md`, `README.md`, `AGENTS.md`) to clarify that releases are only triggered when a PR merged to `main` has the `release` label, and that both git tags and GitHub Releases must use a `v` prefix (e.g., `v1.0.1`). The changelog headings remain bare semver (e.g., `## 1.0.1`). [[1]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL434-R438) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L9-R15) [[3]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceR448-R458) [[4]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL507-R527) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L228-R234) [[6]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L242-R243)

**Version validation and tooling:**

- Added a new `validate-version` command to the changelog Go script (`scripts/changelog/main.go`) and integrated it into the `Makefile` to enforce that only strictly numeric semver versions (no `v` prefix, no pre-release/build metadata) are accepted when generating changelogs. [[1]](diffhunk://#diff-34ee22bcfa2978e1501e8dd13f91d168576882a268763a1c8ee80d4bb310b5e4R8) [[2]](diffhunk://#diff-34ee22bcfa2978e1501e8dd13f91d168576882a268763a1c8ee80d4bb310b5e4L34-R35) [[3]](diffhunk://#diff-34ee22bcfa2978e1501e8dd13f91d168576882a268763a1c8ee80d4bb310b5e4R47-R48) [[4]](diffhunk://#diff-34ee22bcfa2978e1501e8dd13f91d168576882a268763a1c8ee80d4bb310b5e4R106-R124) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L115-R117)

- Updated the changelog update and extraction logic to use the new strict semver validation, ensuring only valid versions are processed. [[1]](diffhunk://#diff-34ee22bcfa2978e1501e8dd13f91d168576882a268763a1c8ee80d4bb310b5e4R198-R201) [[2]](diffhunk://#diff-34ee22bcfa2978e1501e8dd13f91d168576882a268763a1c8ee80d4bb310b5e4L242-R268)

- Added comprehensive tests for the strict semver validation logic in `scripts/changelog/main_test.go`.

**Changelog and release workflow:**

- Added a new release entry for `1.0.1` in `CHANGELOG.md`.

- Improved documentation and examples for using the changelog tooling, specifying that `VERSION` should be numeric only and that the tooling will add the `v` prefix for tags/releases. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L9-R15) [[2]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceR448-R458) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L115-R117)

**Minor documentation cleanups:**

- Fixed formatting and minor issues in `DEVELOPMENT.md` for clarity and consistency. [[1]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL643) [[2]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL657) [[3]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL669)