### PR TITLE
feat: allow users to utilise active workspace on balance command

### DIFF
--- a/cmd/workspace/balance.go
+++ b/cmd/workspace/balance.go
@@ -1,19 +1,21 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"text/tabwriter"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // NewBalanceCommand creates a new command to show the balance of a workspace.
 func NewBalanceCommand(commandName string, c client.API, w io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   commandName + " <workspace-id>",
-		Args:  cobra.ExactArgs(1),
+		Use:   commandName + " [workspace-id]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Show the balance of a workspace",
 		Long: `Show the balance of a workspace
 
@@ -23,11 +25,26 @@ rewards, fees, and VAT. Amounts are shown in the workspace's currency.
 		Example: `
 Show the balance of a workspace
 $ prolific workspace balance <workspace-id>
+
+Show the balance using the workspace set in your config file
+$ prolific workspace balance
+
+Set a default workspace in your config file:
+workspace: <workspace-id>
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := renderWorkspaceBalance(c, args[0], w)
+			workspaceID := viper.GetString("workspace")
+			if len(args) > 0 {
+				workspaceID = args[0]
+			}
+
+			if workspaceID == "" {
+				return errors.New("error: please provide a workspace ID")
+			}
+
+			err := renderWorkspaceBalance(c, workspaceID, w)
 			if err != nil {
-				return fmt.Errorf("error: %s", err.Error())
+				return fmt.Errorf("error: %s", err)
 			}
 
 			return nil
@@ -48,12 +65,13 @@ func renderWorkspaceBalance(c client.API, workspaceID string, w io.Writer) error
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 1, 2, ' ', 0)
+	fmt.Fprintf(tw, "ID:\t%s\n", workspaceID)
 	fmt.Fprintf(tw, "Currency:\t%s\n", balance.CurrencyCode)
 	fmt.Fprintf(tw, "\n")
-	fmt.Fprintf(tw, "Total Balance:\t%.2f\n", toCurrency(balance.TotalBalance))
-	fmt.Fprintf(tw, "  Rewards:\t%.2f\n", toCurrency(balance.BalanceBreakdown.Rewards))
-	fmt.Fprintf(tw, "  Fees:\t%.2f\n", toCurrency(balance.BalanceBreakdown.Fees))
-	fmt.Fprintf(tw, "  VAT:\t%.2f\n", toCurrency(balance.BalanceBreakdown.VAT))
+	fmt.Fprintf(tw, "Total Balance:\t\t\t%.2f\n", toCurrency(balance.TotalBalance))
+	fmt.Fprintf(tw, "  Rewards:\t\t\t%.2f\n", toCurrency(balance.BalanceBreakdown.Rewards))
+	fmt.Fprintf(tw, "  Fees:\t\t\t%.2f\n", toCurrency(balance.BalanceBreakdown.Fees))
+	fmt.Fprintf(tw, "  VAT:\t\t\t%.2f\n", toCurrency(balance.BalanceBreakdown.VAT))
 	fmt.Fprintf(tw, "\n")
 	fmt.Fprintf(tw, "Available Balance:\t%.2f\n", toCurrency(balance.AvailableBalance))
 	fmt.Fprintf(tw, "  Rewards:\t%.2f\n", toCurrency(balance.AvailableBalanceBreakdown.Rewards))

--- a/cmd/workspace/balance_test.go
+++ b/cmd/workspace/balance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prolific-oss/cli/client"
 	"github.com/prolific-oss/cli/cmd/workspace"
 	"github.com/prolific-oss/cli/mock_client"
+	"github.com/spf13/viper"
 )
 
 func TestNewBalanceCommand(t *testing.T) {
@@ -21,8 +22,8 @@ func TestNewBalanceCommand(t *testing.T) {
 
 	cmd := workspace.NewBalanceCommand("balance", c, os.Stdout)
 
-	if cmd.Use != "balance <workspace-id>" {
-		t.Fatalf("expected use: balance <workspace-id>; got %s", cmd.Use)
+	if cmd.Use != "balance [workspace-id]" {
+		t.Fatalf("expected use: balance [workspace-id]; got %s", cmd.Use)
 	}
 
 	if cmd.Short != "Show the balance of a workspace" {
@@ -63,12 +64,13 @@ func TestNewBalanceCommandCallsAPI(t *testing.T) {
 
 	writer.Flush()
 
-	expected := `Currency:  USD
+	expected := `ID:        abc123
+Currency:  USD
 
-Total Balance:  14.28
-  Rewards:      14.28
-  Fees:         0.00
-  VAT:          0.00
+Total Balance:      14.28
+  Rewards:          14.28
+  Fees:             0.00
+  VAT:              0.00
 
 Available Balance:  14.28
   Rewards:          14.28
@@ -99,6 +101,58 @@ func TestNewBalanceCommandHandlesErrors(t *testing.T) {
 	err := cmd.RunE(cmd, []string{workspaceID})
 
 	expected := fmt.Sprintf("error: %s", errorMessage)
+	if err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
+	}
+}
+
+func TestNewBalanceCommandUsesViperWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	workspaceID := "viper-workspace-id"
+
+	viper.Set("workspace", workspaceID)
+	t.Cleanup(func() { viper.Reset() })
+
+	response := client.WorkspaceBalanceResponse{
+		CurrencyCode:     "USD",
+		TotalBalance:     0,
+		AvailableBalance: 0,
+	}
+
+	c.
+		EXPECT().
+		GetWorkspaceBalance(workspaceID).
+		Return(&response, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := workspace.NewBalanceCommand("balance", c, writer)
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error; got %s", err)
+	}
+}
+
+func TestNewBalanceCommandErrorsWithNoWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	viper.Reset()
+
+	cmd := workspace.NewBalanceCommand("balance", c, os.Stdout)
+	err := cmd.RunE(cmd, []string{})
+
+	if err == nil {
+		t.Fatal("expected an error; got nil")
+	}
+
+	expected := "error: please provide a workspace ID"
 	if err.Error() != expected {
 		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, err.Error())
 	}


### PR DESCRIPTION
Folks can set their "active" workspace in a config file. This is used as
a default where we have `--workspace` as an option. This change aims to
do the same thing here by making it the default arg if none are
  specified.
