### PR TITLE
fix(DCP-2903): upgrade Go to 1.26.3 for std/net CVE fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint Go
         uses: golangci/golangci-lint-action@v9.2.0
         with:
-          version: latest
+          version: v2.11.2
           args: --verbose
 
       - name: Lint Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 LABEL maintainer="Ben Selby <ben.selby@prolific.com>"
 
 ENV APPNAME=prolific

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install: install-binary ## Install dependencies and the prolific binary
 	cp scripts/hooks/commit-msg .git/hooks/commit-msg
 	go install github.com/golang/mock/mockgen@master
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.2
 	go install golang.org/x/tools/cmd/goimports@latest
 	go get ./...
 

--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -261,6 +261,7 @@ var operations = []operation{
 	{operationID: "create-study", call: func(c *client.Client) {
 		c.CreateStudy(model.CreateStudy{
 			Name:                    "t",
+			ExternalStudyURL:        "https://example.com/study?p={{%PROLIFIC_PID%}}",
 			ProlificIDOption:        "url_parameters",
 			TotalAvailablePlaces:    10,
 			EstimatedCompletionTime: 5,
@@ -315,7 +316,6 @@ var operations = []operation{
 	{operationID: "request-submission-return", call: func(c *client.Client) {
 		c.RequestSubmissionReturn("sub-id", []string{"no longer needed"})
 	}},
-	{operationID: "get-submission-demographics", skip: "OUTOFSCOPE: submission demographics not exposed in CLI"},
 	{operationID: "bulk-approve-submissions", call: func(c *client.Client) {
 		c.BulkApproveSubmissions(client.BulkApproveSubmissionsPayload{
 			SubmissionIDs: []string{"sub-id"},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prolific-oss/cli
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // MIT


### PR DESCRIPTION
## Summary

Upgrades Go toolchain 1.26.1 → 1.26.3 to remediate two Snyk-reported high-severity stdlib vulnerabilities. Includes two small unrelated unblockers needed for CI to go green (see "Scope creep" below).

Jira: [DCP-2903](https://prolific.atlassian.net/browse/DCP-2903) (parent: DCP-914)

## CVEs fixed

| Snyk ID | CVE | CVSS | CWE | Component |
|---|---|---|---|---|
| SNYK-GOLANG-STDNET-16535159 | [CVE-2026-33811](https://github.com/golang/go/issues/78803) | 8.7 | CWE-415 (Double Free) | `net.LookupCNAME` via cgo resolver |
| SNYK-GOLANG-STDNETHTTP-16535158 | [CVE-2026-33814](https://github.com/golang/go/issues/78476) | 8.7 | CWE-835 (Infinite Loop) | HTTP/2 transport on `SETTINGS_MAX_FRAME_SIZE=0` |

Both fixes ship in [Go 1.26.3](https://groups.google.com/g/golang-announce/c/qcCIEXso47M) (2026-05-07).

This binary builds with `CGO_ENABLED=1`, so the cgo-resolver path in CVE-2026-33811 is reachable — the upgrade fixes a materially vulnerable code path, not just a Snyk score.

## Commits

| Commit | Change |
|---|---|
| `fix(DCP-2903): upgrade Go to 1.26.3 for std/net CVE fixes` | `go.mod`: `go 1.26.1` → `go 1.26.3`; `Dockerfile`: `golang:1.26.1-alpine` → `golang:1.26.3-alpine`. CI workflows already use `1.26.x` glob — no change. |
| `ci(DCP-2903): pin golangci-lint to v2.11.2 in CI and local install` | See "Scope creep" |
| `test(DCP-2903): sync contract test with updated openapi spec` | See "Scope creep" |

## Scope creep (why two extra commits)

**1. `golangci-lint` version pin (v2.11.2)**

`.github/workflows/go.yml` was using `version: latest` for `golangci-lint-action`. golangci-lint 2.12 (released 2026-05-06) introduced new analyzers (`govet inline`, stricter `goconst`) that flag pre-existing code throughout the repo (`slices.Contains` calls, repeated test-string literals). Every PR opened against main today fails the lint job for the same reason — main itself would also be red on re-run.

Pinning both CI (`.github/workflows/go.yml`) and local install (`Makefile`) to `v2.11.2` (the last known-green version) restores deterministic lint behaviour. A follow-up ticket should be filed to address the underlying lint debt and re-evaluate the pin.

**2. Contract test sync**

`make test` runs `contract_test/`, which downloads `https://docs.prolific.com/openapi.yaml` fresh each run and validates client calls against it. The Prolific public API spec has changed since `047d6af` (when the contract test was added): `get-submission-demographics` operation was removed, and `external_study_url` is now required on `create-study`. The test correctly flagged this drift — but main hasn't been re-run, so it's currently broken on main too. Synced the test fixtures to match today's spec.

## Test plan

- [x] `make build` succeeds (Go auto-downloaded 1.26.3 toolchain)
- [x] `make test` — all packages pass including `contract_test/`
- [x] `make lint` — 0 issues (with pinned v2.11.2)
- [x] `go version ./prolific` reports `go1.26.3`
- [x] `go version -m ./prolific` confirms `CGO_ENABLED=1` (vulnerable path exists, now patched)
- [x] CI green

[DCP-2903]: https://prolific.atlassian.net/browse/DCP-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ