### PR TITLE
feat(DCP-3035): add batch_items support to batch create and update commands

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -129,6 +129,18 @@ type API interface {
 	GetAITaskBuilderDatasetUploadURL(datasetID, fileName string) (*GetAITaskBuilderDatasetUploadURLResponse, error)
 }
 
+// UnrecognizedAPIError is returned by Execute when the response body does not match any known
+// error format. Callers can type-assert via errors.As to inspect the raw body and apply
+// their own formatting.
+type UnrecognizedAPIError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *UnrecognizedAPIError) Error() string {
+	return fmt.Sprintf("request failed with status %d: %s", e.StatusCode, string(e.Body))
+}
+
 // Client is responsible for interacting with the Prolific API.
 type Client struct {
 	Client  *http.Client
@@ -207,8 +219,8 @@ func (c *Client) Execute(method, url string, body any, response any) (*http.Resp
 			return nil, fmt.Errorf("request failed: %s - %s", simpleError.Message, simpleError.Detail)
 		}
 
-		// If both fail, return generic error with status code
-		return nil, fmt.Errorf("request failed with status %d: %s", httpResponse.StatusCode, string(responseBody))
+		// If both fail, return a typed error so callers can inspect the raw body
+		return nil, &UnrecognizedAPIError{StatusCode: httpResponse.StatusCode, Body: responseBody}
 	}
 
 	if response != nil {
@@ -1255,20 +1267,56 @@ func (c *Client) UpdateAITaskBuilderBatch(params UpdateBatchParams) (*UpdateAITa
 		Name:        params.Name,
 		DatasetID:   params.DatasetID,
 		TaskDetails: params.TaskDetails,
+		BatchItems:  params.BatchItems,
 	}
 
 	url := fmt.Sprintf("/api/v1/data-collection/batches/%s", params.BatchID)
 	httpResponse, err := c.Execute(http.MethodPatch, url, payload, &response)
 	if err != nil {
+		var apiErr *UnrecognizedAPIError
+		if errors.As(err, &apiErr) {
+			return nil, fmt.Errorf("unable to update batch: %s", formatBatchErrorBody(apiErr.Body))
+		}
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to update batch: %v", string(body))
+		return nil, fmt.Errorf("unable to update batch: %s", formatBatchErrorBody(body))
 	}
 
 	return &response, nil
+}
+
+// formatBatchErrorBody returns a human-readable error string from a batch API error response body.
+// For INVALID_BATCH_ITEMS errors it formats each validation issue; otherwise it returns the raw body.
+func formatBatchErrorBody(body []byte) string {
+	var apiErr struct {
+		Type   string `json:"type"`
+		Issues []struct {
+			Page    int    `json:"page"`
+			Row     int    `json:"row"`
+			Column  int    `json:"column"`
+			Item    int    `json:"item"`
+			Type    string `json:"type"`
+			Field   string `json:"field,omitempty"`
+			Message string `json:"message"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal(body, &apiErr); err != nil || apiErr.Type != "INVALID_BATCH_ITEMS" {
+		return string(body)
+	}
+
+	msg := "batch_items validation failed:"
+	for _, issue := range apiErr.Issues {
+		location := fmt.Sprintf("Page %d, Row %d, Column %d, Item %d (%s)",
+			issue.Page+1, issue.Row+1, issue.Column+1, issue.Item+1, issue.Type)
+		if issue.Field != "" {
+			location = fmt.Sprintf("%s %q", location, issue.Field)
+		}
+		msg += fmt.Sprintf("\n  %s: %s", location, issue.Message)
+	}
+	return msg
 }
 
 // GetAITaskBuilderBatch will return details of an AI Task Builder batch.
@@ -1408,17 +1456,22 @@ func (c *Client) CreateAITaskBuilderBatch(params CreateBatchParams) (*CreateAITa
 			TaskIntroduction: params.TaskIntroduction,
 			TaskSteps:        params.TaskSteps,
 		},
+		BatchItems: params.BatchItems,
 	}
 
 	url := "/api/v1/data-collection/batches"
 	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
 	if err != nil {
+		var apiErr *UnrecognizedAPIError
+		if errors.As(err, &apiErr) {
+			return nil, fmt.Errorf("unable to create batch: %s", formatBatchErrorBody(apiErr.Body))
+		}
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to create batch: %v", string(body))
+		return nil, fmt.Errorf("unable to create batch: %s", formatBatchErrorBody(body))
 	}
 
 	return &response, nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestFormatBatchErrorBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     []byte
+		expected string
+	}{
+		{
+			name:     "non-JSON body returned as-is",
+			body:     []byte("internal server error"),
+			expected: "internal server error",
+		},
+		{
+			name:     "non-INVALID_BATCH_ITEMS error returned as-is",
+			body:     []byte(`{"type":"SOME_OTHER_ERROR","message":"something went wrong"}`),
+			expected: `{"type":"SOME_OTHER_ERROR","message":"something went wrong"}`,
+		},
+		{
+			name:     "INVALID_BATCH_ITEMS with no issues",
+			body:     []byte(`{"type":"INVALID_BATCH_ITEMS","issues":[]}`),
+			expected: "batch_items validation failed:",
+		},
+		{
+			name:     "INVALID_BATCH_ITEMS with single issue, no field",
+			body:     []byte(`{"type":"INVALID_BATCH_ITEMS","issues":[{"page":0,"row":0,"column":0,"item":0,"type":"free_text","message":"description is required"}]}`),
+			expected: "batch_items validation failed:\n  Page 1, Row 1, Column 1, Item 1 (free_text): description is required",
+		},
+		{
+			name:     "INVALID_BATCH_ITEMS with field reference",
+			body:     []byte(`{"type":"INVALID_BATCH_ITEMS","issues":[{"page":0,"row":1,"column":0,"item":2,"type":"dataset_field","field":"missing_col","message":"Field does not exist in the dataset schema"}]}`),
+			expected: "batch_items validation failed:\n  Page 1, Row 2, Column 1, Item 3 (dataset_field) \"missing_col\": Field does not exist in the dataset schema",
+		},
+		{
+			name:     "INVALID_BATCH_ITEMS with multiple issues",
+			body:     []byte(`{"type":"INVALID_BATCH_ITEMS","issues":[{"page":0,"row":0,"column":0,"item":0,"type":"free_text","message":"description is required"},{"page":1,"row":2,"column":1,"item":3,"type":"multiple_choice","message":"answer_limit exceeds number of options"}]}`),
+			expected: "batch_items validation failed:\n  Page 1, Row 1, Column 1, Item 1 (free_text): description is required\n  Page 2, Row 3, Column 2, Item 4 (multiple_choice): answer_limit exceeds number of options",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatBatchErrorBody(tt.body)
+			if got != tt.expected {
+				t.Fatalf("expected:\n%q\ngot:\n%q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -1,5 +1,7 @@
 package client
 
+import "encoding/json"
+
 // SendMessagePayload represents the JSON payload for sending a message.
 type SendMessagePayload struct {
 	RecipientID string `json:"recipient_id"`
@@ -83,12 +85,13 @@ type CreateAITaskBuilderDatasetPayload struct {
 
 // CreateBatchParams represents the parameters for creating an AI Task Builder batch.
 type CreateBatchParams struct {
-	Name             string `json:"name"`
-	WorkspaceID      string `json:"workspace_id"`
-	DatasetID        string `json:"dataset_id"`
-	TaskName         string `json:"task_name"`
-	TaskIntroduction string `json:"task_introduction"`
-	TaskSteps        string `json:"task_steps"`
+	Name             string          `json:"name"`
+	WorkspaceID      string          `json:"workspace_id"`
+	DatasetID        string          `json:"dataset_id"`
+	TaskName         string          `json:"task_name"`
+	TaskIntroduction string          `json:"task_introduction"`
+	TaskSteps        string          `json:"task_steps"`
+	BatchItems       json.RawMessage // nil means omit from payload
 }
 
 // UpdateBatchParams represents the parameters for updating an AI Task Builder batch.
@@ -96,14 +99,16 @@ type UpdateBatchParams struct {
 	BatchID     string
 	Name        string
 	DatasetID   string
-	TaskDetails *TaskDetails // nil means task details will not be updated
+	TaskDetails *TaskDetails    // nil means task details will not be updated
+	BatchItems  json.RawMessage // nil = omit, json.RawMessage("null") = clear, JSON array = set
 }
 
 // UpdateAITaskBuilderBatchPayload represents the JSON payload for updating an AI Task Builder batch.
 type UpdateAITaskBuilderBatchPayload struct {
-	Name        string       `json:"name,omitempty"`
-	DatasetID   string       `json:"dataset_id,omitempty"`
-	TaskDetails *TaskDetails `json:"task_details,omitempty"`
+	Name        string          `json:"name,omitempty"`
+	DatasetID   string          `json:"dataset_id,omitempty"`
+	TaskDetails *TaskDetails    `json:"task_details,omitempty"`
+	BatchItems  json.RawMessage `json:"batch_items,omitempty"`
 }
 
 // TaskDetails represents the task configuration details for batch creation
@@ -115,10 +120,11 @@ type TaskDetails struct {
 
 // CreateAITaskBuilderBatchPayload represents the JSON payload for creating an AI Task Builder batch
 type CreateAITaskBuilderBatchPayload struct {
-	Name        string      `json:"name"`
-	WorkspaceID string      `json:"workspace_id"`
-	DatasetID   string      `json:"dataset_id"`
-	TaskDetails TaskDetails `json:"task_details"`
+	Name        string          `json:"name"`
+	WorkspaceID string          `json:"workspace_id"`
+	DatasetID   string          `json:"dataset_id"`
+	TaskDetails TaskDetails     `json:"task_details"`
+	BatchItems  json.RawMessage `json:"batch_items,omitempty"`
 }
 
 // InstructionType represents the type of instruction.

--- a/cmd/aitaskbuilder/batch_create.go
+++ b/cmd/aitaskbuilder/batch_create.go
@@ -17,6 +17,8 @@ type BatchCreateOptions struct {
 	TaskName         string
 	TaskIntroduction string
 	TaskSteps        string
+	BatchItemsFile   string
+	BatchItemsJSON   string
 }
 
 func NewBatchCreateCommand(client client.API, w io.Writer) *cobra.Command {
@@ -29,10 +31,20 @@ func NewBatchCreateCommand(client client.API, w io.Writer) *cobra.Command {
 
 This command creates a batch in a workspace and links it to a dataset. The dataset must
 be in READY status before you can create a batch with it. You must provide the batch name,
-workspace ID, dataset ID, and task details (name, introduction, and steps).`,
+workspace ID, dataset ID, and task details (name, introduction, and steps).
+
+Optionally, supply batch_items to define the participant task layout as a structured
+JSON schema (pages → rows → columns → items). Provide batch_items from a file with
+-f or as an inline JSON string with -j. See docs/examples/batch-items.json for an example.`,
 		Example: `
 Create a batch:
 $ prolific aitaskbuilder batch create -n "My Data Collection Batch" -w 6278acb09062db3b35bcbeb0 -d 1234acb09999db4b99bcded1 --task-name "Sample Task" --task-introduction "This is a sample task for testing" --task-steps "1. Review the data\n2. Provide your response"
+
+Create a batch with batch_items from a file:
+$ prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <dataset_id> --task-name "Task" --task-introduction "Intro" --task-steps "Steps" -f batch-items.json
+
+Create a batch with inline batch_items JSON:
+$ prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <dataset_id> --task-name "Task" --task-introduction "Intro" --task-steps "Steps" -j '[{"rows":[{"columns":[{"items":[{"type":"free_text","description":"Describe your observations."}]}]}]}]'
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Args = args
@@ -53,6 +65,8 @@ $ prolific aitaskbuilder batch create -n "My Data Collection Batch" -w 6278acb09
 	flags.StringVar(&opts.TaskName, "task-name", "", "Task name (required) - The name of the task.")
 	flags.StringVar(&opts.TaskIntroduction, "task-introduction", "", "Task introduction (required) - The introduction text for the task.")
 	flags.StringVar(&opts.TaskSteps, "task-steps", "", "Task steps (required) - The steps for completing the task.")
+	flags.StringVarP(&opts.BatchItemsFile, "batch-items-file", "f", "", "Path to JSON file containing batch_items layout.")
+	flags.StringVarP(&opts.BatchItemsJSON, "batch-items-json", "j", "", "Inline JSON string containing batch_items layout.")
 
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("workspace-id")
@@ -85,6 +99,11 @@ func createAITaskBuilderBatch(c client.API, opts BatchCreateOptions, w io.Writer
 		return errors.New(ErrTaskStepsRequired)
 	}
 
+	batchItems, err := parseBatchItemsInput(opts.BatchItemsFile, opts.BatchItemsJSON)
+	if err != nil {
+		return err
+	}
+
 	params := client.CreateBatchParams{
 		Name:             opts.Name,
 		WorkspaceID:      opts.WorkspaceID,
@@ -92,6 +111,7 @@ func createAITaskBuilderBatch(c client.API, opts BatchCreateOptions, w io.Writer
 		TaskName:         opts.TaskName,
 		TaskIntroduction: opts.TaskIntroduction,
 		TaskSteps:        opts.TaskSteps,
+		BatchItems:       batchItems,
 	}
 
 	response, err := c.CreateAITaskBuilderBatch(params)

--- a/cmd/aitaskbuilder/batch_create_test.go
+++ b/cmd/aitaskbuilder/batch_create_test.go
@@ -3,9 +3,11 @@ package aitaskbuilder_test
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -202,6 +204,145 @@ func TestNewBatchCreateCommandMissingRequiredFlags(t *testing.T) {
 
 			if err.Error() != tc.expectedErr {
 				t.Fatalf("expected error: %s; got %s", tc.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
+const batchItemsJSON = `[{"rows":[{"columns":[{"items":[{"type":"free_text","description":"Describe your observations."}]}]}]}]`
+
+func baseCreateArgs() []string {
+	return []string{
+		"--name", "Test Batch",
+		"--workspace-id", "6278acb09062db3b35bcbeb0",
+		"--dataset-id", "1234acb09999db4b99bcded1",
+		"--task-name", "Task",
+		"--task-introduction", "Intro",
+		"--task-steps", "Steps",
+	}
+}
+
+func TestNewBatchCreateCommandWithBatchItemsJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := &client.CreateAITaskBuilderBatchResponse{
+		ID:          "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+		CreatedAt:   "2019-08-24T14:15:22Z",
+		CreatedBy:   "user-1",
+		Name:        "Test Batch",
+		Status:      "UNINITIALISED",
+		WorkspaceID: "6278acb09062db3b35bcbeb0",
+	}
+
+	c.EXPECT().CreateAITaskBuilderBatch(client.CreateBatchParams{
+		Name:             "Test Batch",
+		WorkspaceID:      "6278acb09062db3b35bcbeb0",
+		DatasetID:        "1234acb09999db4b99bcded1",
+		TaskName:         "Task",
+		TaskIntroduction: "Intro",
+		TaskSteps:        "Steps",
+		BatchItems:       json.RawMessage(batchItemsJSON),
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchCreateCommand(c, writer)
+	cmd.SetArgs(append(baseCreateArgs(), "--batch-items-json", batchItemsJSON))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+}
+
+func TestNewBatchCreateCommandWithBatchItemsFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	tmpFile := filepath.Join(t.TempDir(), "batch-items.json")
+	if err := os.WriteFile(tmpFile, []byte(batchItemsJSON), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	response := &client.CreateAITaskBuilderBatchResponse{
+		ID:          "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+		CreatedAt:   "2019-08-24T14:15:22Z",
+		CreatedBy:   "user-1",
+		Name:        "Test Batch",
+		Status:      "UNINITIALISED",
+		WorkspaceID: "6278acb09062db3b35bcbeb0",
+	}
+
+	c.EXPECT().CreateAITaskBuilderBatch(client.CreateBatchParams{
+		Name:             "Test Batch",
+		WorkspaceID:      "6278acb09062db3b35bcbeb0",
+		DatasetID:        "1234acb09999db4b99bcded1",
+		TaskName:         "Task",
+		TaskIntroduction: "Intro",
+		TaskSteps:        "Steps",
+		BatchItems:       json.RawMessage(batchItemsJSON),
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchCreateCommand(c, writer)
+	cmd.SetArgs(append(baseCreateArgs(), "--batch-items-file", tmpFile))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+}
+
+func TestNewBatchCreateCommandBatchItemsValidationErrors(t *testing.T) {
+	testCases := []struct {
+		name        string
+		extraArgs   []string
+		expectedErr string
+	}{
+		{
+			name:        "both file and json flags",
+			extraArgs:   []string{"-f", "some-file.json", "-j", batchItemsJSON},
+			expectedErr: "error: " + aitaskbuilder.ErrBothBatchItemsInputsProvided,
+		},
+		{
+			name:        "invalid JSON",
+			extraArgs:   []string{"-j", "not-json"},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMustBeArray,
+		},
+		{
+			name:        "non-array JSON",
+			extraArgs:   []string{"-j", `{"rows":[]}`},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMustBeArray,
+		},
+		{
+			name:        "empty array",
+			extraArgs:   []string{"-j", "[]"},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMustBeNonEmpty,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c := mock_client.NewMockAPI(ctrl)
+
+			var b bytes.Buffer
+			writer := bufio.NewWriter(&b)
+
+			cmd := aitaskbuilder.NewBatchCreateCommand(c, writer)
+			cmd.SetArgs(append(baseCreateArgs(), tc.extraArgs...))
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error; got nil")
+			}
+			if err.Error() != tc.expectedErr {
+				t.Fatalf("expected error: %q; got %q", tc.expectedErr, err.Error())
 			}
 		})
 	}

--- a/cmd/aitaskbuilder/batch_items.go
+++ b/cmd/aitaskbuilder/batch_items.go
@@ -1,0 +1,39 @@
+package aitaskbuilder
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// parseBatchItemsInput reads and validates batch_items JSON from a file path or inline string.
+// Returns nil if neither is provided (omit from payload).
+func parseBatchItemsInput(filePath, jsonStr string) (json.RawMessage, error) {
+	if filePath != "" && jsonStr != "" {
+		return nil, errors.New(ErrBothBatchItemsInputsProvided)
+	}
+
+	var raw []byte
+	if filePath != "" {
+		var err error
+		raw, err = os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read batch-items file: %w", err)
+		}
+	} else if jsonStr != "" {
+		raw = []byte(jsonStr)
+	} else {
+		return nil, nil
+	}
+
+	var pages []json.RawMessage
+	if err := json.Unmarshal(raw, &pages); err != nil {
+		return nil, errors.New(ErrBatchItemsMustBeArray)
+	}
+	if len(pages) == 0 {
+		return nil, errors.New(ErrBatchItemsMustBeNonEmpty)
+	}
+
+	return json.RawMessage(raw), nil
+}

--- a/cmd/aitaskbuilder/batch_update.go
+++ b/cmd/aitaskbuilder/batch_update.go
@@ -1,9 +1,11 @@
 package aitaskbuilder
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/prolific-oss/cli/client"
 	"github.com/spf13/cobra"
@@ -20,6 +22,9 @@ type BatchUpdateOptions struct {
 	TaskNameChanged         bool
 	TaskIntroductionChanged bool
 	TaskStepsChanged        bool
+	BatchItemsFile          string
+	BatchItemsJSON          string
+	ClearBatchItems         bool
 }
 
 func NewBatchUpdateCommand(client client.API, w io.Writer) *cobra.Command {
@@ -32,7 +37,11 @@ func NewBatchUpdateCommand(client client.API, w io.Writer) *cobra.Command {
 
 This command updates a batch's name, dataset, and/or task details. At least one
 field must be provided. Task detail flags can be provided individually — any
-omitted task detail fields will be preserved from the existing batch.`,
+omitted task detail fields will be preserved from the existing batch.
+
+batch_items can be set from a file (-f) or inline JSON (-j), or cleared with
+--clear-batch-items. Clearing batch_items also deletes all associated instructions
+and content blocks for the batch.`,
 		Example: `
 Update a batch name:
 $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -n "Updated Batch Name"
@@ -45,6 +54,12 @@ $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 --
 
 Update name and dataset:
 $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -n "Updated Name" -d 1234acb09999db4b99bcded1
+
+Set batch_items from a file:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -f batch-items.json
+
+Clear batch_items:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 --clear-batch-items
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Args = args
@@ -68,6 +83,9 @@ $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -n
 	flags.StringVar(&opts.TaskName, "task-name", "", "Task name - The new name of the task.")
 	flags.StringVar(&opts.TaskIntroduction, "task-introduction", "", "Task introduction - The new introduction text for the task.")
 	flags.StringVar(&opts.TaskSteps, "task-steps", "", "Task steps - The new steps for completing the task.")
+	flags.StringVarP(&opts.BatchItemsFile, "batch-items-file", "f", "", "Path to JSON file containing batch_items layout.")
+	flags.StringVarP(&opts.BatchItemsJSON, "batch-items-json", "j", "", "Inline JSON string containing batch_items layout.")
+	flags.BoolVar(&opts.ClearBatchItems, "clear-batch-items", false, "Set batch_items to null, removing the configured task layout and deleting all associated instructions and content blocks.")
 
 	_ = cmd.MarkFlagRequired("batch-id")
 
@@ -82,15 +100,32 @@ func updateAITaskBuilderBatch(c client.API, opts BatchUpdateOptions, w io.Writer
 
 	anyTaskDetailChanged := opts.TaskNameChanged || opts.TaskIntroductionChanged || opts.TaskStepsChanged
 	allTaskDetailsChanged := opts.TaskNameChanged && opts.TaskIntroductionChanged && opts.TaskStepsChanged
+	anyBatchItemsChanged := opts.BatchItemsFile != "" || opts.BatchItemsJSON != "" || opts.ClearBatchItems
 
-	if opts.Name == "" && opts.DatasetID == "" && !anyTaskDetailChanged {
+	if opts.Name == "" && opts.DatasetID == "" && !anyTaskDetailChanged && !anyBatchItemsChanged {
 		return errors.New(ErrAtLeastOneUpdateFieldRequired)
 	}
 
+	var batchItems json.RawMessage
+	if opts.ClearBatchItems {
+		if opts.BatchItemsFile != "" || opts.BatchItemsJSON != "" {
+			return errors.New(ErrBatchItemsMutuallyExclusive)
+		}
+		fmt.Fprintln(os.Stderr, "Warning: clearing batch_items will delete all associated instructions and content blocks.")
+		batchItems = json.RawMessage("null")
+	} else if anyBatchItemsChanged {
+		var err error
+		batchItems, err = parseBatchItemsInput(opts.BatchItemsFile, opts.BatchItemsJSON)
+		if err != nil {
+			return err
+		}
+	}
+
 	params := client.UpdateBatchParams{
-		BatchID:   opts.BatchID,
-		Name:      opts.Name,
-		DatasetID: opts.DatasetID,
+		BatchID:    opts.BatchID,
+		Name:       opts.Name,
+		DatasetID:  opts.DatasetID,
+		BatchItems: batchItems,
 	}
 
 	if anyTaskDetailChanged {

--- a/cmd/aitaskbuilder/batch_update_test.go
+++ b/cmd/aitaskbuilder/batch_update_test.go
@@ -3,9 +3,11 @@ package aitaskbuilder_test
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -325,5 +327,171 @@ func TestNewBatchUpdateCommandNoFieldsProvided(t *testing.T) {
 	expectedError := "error: " + aitaskbuilder.ErrAtLeastOneUpdateFieldRequired
 	if err.Error() != expectedError {
 		t.Fatalf("expected error: %s; got %s", expectedError, err.Error())
+	}
+}
+
+func TestNewBatchUpdateCommandWithBatchItemsJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
+	response := &client.UpdateAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:            updateBatchID,
+			CreatedAt:     createdAt,
+			CreatedBy:     "user-1",
+			Name:          "Existing Name",
+			Status:        "UNINITIALISED",
+			WorkspaceID:   "6745ab669112d10b9b3afb48",
+			SchemaVersion: 5,
+			Datasets:      []model.Dataset{},
+		},
+	}
+
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID:    updateBatchID,
+		BatchItems: json.RawMessage(batchItemsJSON),
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", updateBatchID, "--batch-items-json", batchItemsJSON})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+}
+
+func TestNewBatchUpdateCommandWithBatchItemsFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	tmpFile := filepath.Join(t.TempDir(), "batch-items.json")
+	if err := os.WriteFile(tmpFile, []byte(batchItemsJSON), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
+	response := &client.UpdateAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:            updateBatchID,
+			CreatedAt:     createdAt,
+			CreatedBy:     "user-1",
+			Name:          "Existing Name",
+			Status:        "UNINITIALISED",
+			WorkspaceID:   "6745ab669112d10b9b3afb48",
+			SchemaVersion: 5,
+			Datasets:      []model.Dataset{},
+		},
+	}
+
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID:    updateBatchID,
+		BatchItems: json.RawMessage(batchItemsJSON),
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", updateBatchID, "--batch-items-file", tmpFile})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+}
+
+func TestNewBatchUpdateCommandClearBatchItems(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2025-02-27T18:03:59.795Z")
+	response := &client.UpdateAITaskBuilderBatchResponse{
+		AITaskBuilderBatch: model.AITaskBuilderBatch{
+			ID:            updateBatchID,
+			CreatedAt:     createdAt,
+			CreatedBy:     "user-1",
+			Name:          "Existing Name",
+			Status:        "UNINITIALISED",
+			WorkspaceID:   "6745ab669112d10b9b3afb48",
+			SchemaVersion: 5,
+			Datasets:      []model.Dataset{},
+		},
+	}
+
+	c.EXPECT().UpdateAITaskBuilderBatch(client.UpdateBatchParams{
+		BatchID:    updateBatchID,
+		BatchItems: json.RawMessage("null"),
+	}).Return(response, nil)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+	cmd.SetArgs([]string{"--batch-id", updateBatchID, "--clear-batch-items"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+}
+
+func TestNewBatchUpdateCommandBatchItemsValidationErrors(t *testing.T) {
+	testCases := []struct {
+		name        string
+		args        []string
+		expectedErr string
+	}{
+		{
+			name:        "both file and json flags",
+			args:        []string{"--batch-id", updateBatchID, "-f", "some-file.json", "-j", batchItemsJSON},
+			expectedErr: "error: " + aitaskbuilder.ErrBothBatchItemsInputsProvided,
+		},
+		{
+			name:        "clear with file flag",
+			args:        []string{"--batch-id", updateBatchID, "--clear-batch-items", "-f", "some-file.json"},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMutuallyExclusive,
+		},
+		{
+			name:        "clear with json flag",
+			args:        []string{"--batch-id", updateBatchID, "--clear-batch-items", "-j", batchItemsJSON},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMutuallyExclusive,
+		},
+		{
+			name:        "invalid JSON",
+			args:        []string{"--batch-id", updateBatchID, "-j", "not-json"},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMustBeArray,
+		},
+		{
+			name:        "empty array",
+			args:        []string{"--batch-id", updateBatchID, "-j", "[]"},
+			expectedErr: "error: " + aitaskbuilder.ErrBatchItemsMustBeNonEmpty,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c := mock_client.NewMockAPI(ctrl)
+
+			var b bytes.Buffer
+			writer := bufio.NewWriter(&b)
+
+			cmd := aitaskbuilder.NewBatchUpdateCommand(c, writer)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error; got nil")
+			}
+			if err.Error() != tc.expectedErr {
+				t.Fatalf("expected error: %q; got %q", tc.expectedErr, err.Error())
+			}
+		})
 	}
 }

--- a/cmd/aitaskbuilder/constants.go
+++ b/cmd/aitaskbuilder/constants.go
@@ -6,6 +6,10 @@ const (
 	ErrBatchIDRequired               = "batch ID is required"
 	ErrBatchNotFound                 = "batch not found"
 	ErrBothInstructionInputsProvided = "cannot specify both instructions file (-f) and JSON string (-j)"
+	ErrBothBatchItemsInputsProvided  = "cannot specify both batch-items file (-f) and batch-items JSON (-j)"
+	ErrBatchItemsMutuallyExclusive   = "cannot combine --clear-batch-items with batch-items file (-f) or batch-items JSON (-j)"
+	ErrBatchItemsMustBeArray         = "batch_items must be a JSON array"
+	ErrBatchItemsMustBeNonEmpty      = "batch_items must contain at least one page"
 	ErrDatasetIDRequired             = "dataset ID is required"
 	ErrDatasetNotFound               = "dataset not found"
 	ErrInstructionInputRequired      = "either instructions file (-f) or JSON string (-j) must be provided"
@@ -15,5 +19,5 @@ const (
 	ErrTaskStepsRequired             = "task steps is required"
 	ErrTasksPerGroupMinimum          = "tasks per group must be at least 1"
 	ErrWorkspaceIDRequired           = "workspace ID is required"
-	ErrAtLeastOneUpdateFieldRequired = "at least one of --name, --dataset-id, or task detail flags must be provided"
+	ErrAtLeastOneUpdateFieldRequired = "at least one of --name, --dataset-id, task detail flags, or batch-items flags must be provided"
 )

--- a/docs/examples/batch-items.json
+++ b/docs/examples/batch-items.json
@@ -1,0 +1,28 @@
+[
+  {
+    "rows": [
+      {
+        "columns": [
+          {
+            "items": [
+              {
+                "type": "free_text",
+                "description": "Please describe your observations."
+              },
+              {
+                "type": "multiple_choice",
+                "description": "How confident are you in your answer?",
+                "answer_limit": 1,
+                "options": [
+                  { "label": "Very confident", "value": "very_confident" },
+                  { "label": "Somewhat confident", "value": "somewhat_confident" },
+                  { "label": "Not confident", "value": "not_confident" }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Extends `aitaskbuilder batch create` and `aitaskbuilder batch update` to support the `batch_items` field (DCP-3014), allowing customers to define participant task layouts (pages → rows → columns → items) via the CLI.

## Usage

```bash
# Create with batch_items from a file
prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <dataset_id> \
  --task-name "Task" --task-introduction "Intro" --task-steps "Steps" \
  -f docs/examples/batch-items.json

# Update with inline JSON
prolific aitaskbuilder batch update -b <batch_id> \
  -j '[{"rows":[{"columns":[{"items":[{"type":"free_text","description":"Describe your observations."}]}]}]}]'

# Clear batch_items (also deletes associated instructions and content blocks)
prolific aitaskbuilder batch update -b <batch_id> --clear-batch-items
```

Invalid `batch_items` surfaces structured errors from the API:

```
error: unable to update batch: batch_items validation failed:
  Page 1, Row 1, Column 1, Item 1 (dataset_field) "missing_field": Field does not exist in the dataset
```

## Implementation

- `client/payloads.go` — `BatchItems json.RawMessage` added to params and payload structs
- `client/client.go` — `UnrecognizedAPIError` typed error from `Execute` allows batch methods to intercept and format `INVALID_BATCH_ITEMS` 422 responses via `errors.As`
- `cmd/aitaskbuilder/batch_items.go` — shared `parseBatchItemsInput` helper with validation and mutual exclusion
- `cmd/aitaskbuilder/batch_create.go` / `batch_update.go` — new `-f`, `-j`, `--clear-batch-items` flags; clear operation prints a destructive-action warning to stderr
- `docs/examples/batch-items.json` — example layout file

## Testing

- Unit tests for `formatBatchErrorBody` (all error format cases, 1-based index verification)
- Batch create/update: file input, inline JSON, `--clear-batch-items`, all validation error paths
- Manually verified against orange dev including structured 422 error formatting