### PR TITLE
fix: add missing OpenAPI operations to contract test coverage table

### DIFF
--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -198,7 +198,9 @@ var operations = []operation{
 		c.CreateAITaskBuilderDataset("ws-id", client.CreateAITaskBuilderDatasetPayload{Name: "t"})
 	}},
 	{operationID: "get-dataset-upload-url", call: func(c *client.Client) { c.GetAITaskBuilderDatasetUploadURL("ds-id", "data") }},
+	{operationID: "get-task-builder-dataset", skip: "OUTOFSCOPE: no CLI command for retrieving a specific dataset by ID"},
 	{operationID: "get-task-builder-dataset-status", call: func(c *client.Client) { c.GetAITaskBuilderDatasetStatus("ds-id") }},
+	{operationID: "get-dataset-import-status", skip: "OUTOFSCOPE: no CLI command for dataset import status"},
 
 	// AI Task Builder — Instructions
 	{operationID: "get-task-builder-instructions", skip: "OUTOFSCOPE: no CLI command for getting task builder instructions"},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds two missing `operationId` entries to the contract test coverage table in `contract_test/contract_test.go`, fixing the failing `TestAPICoverage` test that was causing CI to fail on the dependabot PR (#442).

## Why

The Prolific OpenAPI spec at `https://docs.prolific.com/openapi.yaml` was updated to include two new endpoints that were not present in the coverage table:

- `get-task-builder-dataset` — `GET /api/v1/data-collection/datasets/{dataset_id}`: retrieves a specific AI Task Builder dataset by ID
- `get-dataset-import-status` — `GET /api/v1/data-collection/datasets/{dataset_id}/imports/{import_id}`: returns the status of a V4 dataset import job

The `TestAPICoverage` test enforces that every `operationId` in the live spec is either covered by a client call or explicitly skipped. Both new operations have no corresponding CLI commands, so they are marked `OUTOFSCOPE`.

## Testing

`TestAPICoverage` now passes locally. Full `make test` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7bdcd72-c549-4615-8bce-54f452ce4c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7bdcd72-c549-4615-8bce-54f452ce4c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

