### PR TITLE
fix(DCP-3144): emit V3 rows/columns/items for collection create/update

### DIFF
--- a/cmd/collection/constants.go
+++ b/cmd/collection/constants.go
@@ -3,7 +3,7 @@ package collection
 const (
 	// Error messages
 	ErrCollectionItemsRequired  = "at least one collection item must be provided"
-	ErrPageItemsRequired        = "each page must have at least one item in page_items"
+	ErrItemsRequired            = "each page must have at least one item"
 	ErrWorkspaceIDRequired      = "workspace ID is required"
 	ErrNameRequired             = "name is required"
 	ErrWorkspaceNotFound        = "workspace not found"

--- a/cmd/collection/create_collection.go
+++ b/cmd/collection/create_collection.go
@@ -33,6 +33,9 @@ To create a collection via the CLI, define your collection as a JSON/YAML file
 $ prolific collection create -t docs/examples/collection.json
 $ prolific collection create -t docs/examples/collection.yaml
 
+Collection items use the rows -> columns -> items structure. The deprecated
+page_items shape is still accepted and converted automatically.
+
 An example of a JSON collection file:
 
 {
@@ -46,27 +49,35 @@ An example of a JSON collection file:
   "collection_items": [
     {
       "order": 0,
-      "page_items": [
+      "rows": [
         {
-          "order": 0,
-          "type": "free_text",
-          "description": "How was your experience completing this task?"
-        },
-        {
-          "order": 1,
-          "type": "multiple_choice",
-          "description": "Which option do you prefer?",
-          "options": [
+          "columns": [
             {
-              "label": "Response 1",
-              "value": "response1"
-            },
-            {
-              "label": "Response 2",
-              "value": "response2"
+              "items": [
+                {
+                  "order": 0,
+                  "type": "free_text",
+                  "description": "How was your experience completing this task?"
+                },
+                {
+                  "order": 1,
+                  "type": "multiple_choice",
+                  "description": "Which option do you prefer?",
+                  "options": [
+                    {
+                      "label": "Response 1",
+                      "value": "response1"
+                    },
+                    {
+                      "label": "Response 2",
+                      "value": "response2"
+                    }
+                  ],
+                  "answer_limit": -1
+                }
+              ]
             }
-          ],
-          "answer_limit": -1
+          ]
         }
       ]
     }
@@ -84,19 +95,21 @@ task_details:
   task_steps: "<ol><li>Example Step 1</li><li>Example Step 2</li></ol>"
 collection_items:
   - order: 0
-    page_items:
-      - order: 0
-        type: free_text
-        description: How was your experience completing this task?
-      - order: 1
-        type: multiple_choice
-        description: Which option do you prefer?
-        options:
-          - label: Response 1
-            value: response1
-          - label: Response 2
-            value: response2
-        answer_limit: -1
+    rows:
+      - columns:
+          - items:
+              - order: 0
+                type: free_text
+                description: How was your experience completing this task?
+              - order: 1
+                type: multiple_choice
+                description: Which option do you prefer?
+                options:
+                  - label: Response 1
+                    value: response1
+                  - label: Response 2
+                    value: response2
+                answer_limit: -1
 ---`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Args = args
@@ -176,6 +189,10 @@ func createCollection(c client.API, opts CreateCollectionOptions, w io.Writer) e
 	if err := validatePayload(payload); err != nil {
 		return err
 	}
+
+	// Convert any deprecated v2 page_items input into the V3 rows/columns/items
+	// structure so the payload is always sent as V3.
+	payload.NormaliseToV3()
 
 	collection, err := c.CreateAITaskBuilderCollection(payload)
 	if err != nil {

--- a/cmd/collection/create_collection_test.go
+++ b/cmd/collection/create_collection_test.go
@@ -285,12 +285,13 @@ collection_items:
 
 	// Verify first page - content blocks
 	firstPage := capturedPayload.CollectionItems[0]
-	if len(firstPage.PageItems) != 2 {
-		t.Fatalf("expected 2 page items in first page; got %d", len(firstPage.PageItems))
+	firstPageItems := firstPage.Rows[0].Columns[0].Items
+	if len(firstPageItems) != 2 {
+		t.Fatalf("expected 2 page items in first page; got %d", len(firstPageItems))
 	}
 
 	// Verify rich_text content block
-	richTextItem := firstPage.PageItems[0]
+	richTextItem := firstPageItems[0]
 	if richTextItem.Type != "rich_text" {
 		t.Fatalf("expected type 'rich_text'; got '%s'", richTextItem.Type)
 	}
@@ -299,7 +300,7 @@ collection_items:
 	}
 
 	// Verify image content block
-	imageItem := firstPage.PageItems[1]
+	imageItem := firstPageItems[1]
 	if imageItem.Type != "image" {
 		t.Fatalf("expected type 'image'; got '%s'", imageItem.Type)
 	}
@@ -315,11 +316,12 @@ collection_items:
 
 	// Verify second page - instructions with disable_dropdown
 	secondPage := capturedPayload.CollectionItems[1]
-	if len(secondPage.PageItems) != 2 {
-		t.Fatalf("expected 2 page items in second page; got %d", len(secondPage.PageItems))
+	secondPageItems := secondPage.Rows[0].Columns[0].Items
+	if len(secondPageItems) != 2 {
+		t.Fatalf("expected 2 page items in second page; got %d", len(secondPageItems))
 	}
 
-	multipleChoiceItem := secondPage.PageItems[1]
+	multipleChoiceItem := secondPageItems[1]
 	if multipleChoiceItem.Type != "multiple_choice" {
 		t.Fatalf("expected type 'multiple_choice'; got '%s'", multipleChoiceItem.Type)
 	}
@@ -611,11 +613,12 @@ func TestNewCreateCollectionCommandWithContentBlocks(t *testing.T) {
 	}
 
 	firstPage := capturedPayload.CollectionItems[0]
-	if len(firstPage.PageItems) != 2 {
-		t.Fatalf("expected 2 page items in first page; got %d", len(firstPage.PageItems))
+	firstPageItems := firstPage.Rows[0].Columns[0].Items
+	if len(firstPageItems) != 2 {
+		t.Fatalf("expected 2 page items in first page; got %d", len(firstPageItems))
 	}
 
-	richTextItem := firstPage.PageItems[0]
+	richTextItem := firstPageItems[0]
 	if richTextItem.Type != "rich_text" {
 		t.Fatalf("expected type 'rich_text'; got '%s'", richTextItem.Type)
 	}
@@ -623,7 +626,7 @@ func TestNewCreateCollectionCommandWithContentBlocks(t *testing.T) {
 		t.Fatalf("expected rich_text content to be set; got '%s'", richTextItem.Content)
 	}
 
-	imageItem := firstPage.PageItems[1]
+	imageItem := firstPageItems[1]
 	if imageItem.Type != "image" {
 		t.Fatalf("expected type 'image'; got '%s'", imageItem.Type)
 	}
@@ -694,12 +697,20 @@ func TestNewCreateCollectionCommandPassesThroughContentFormatJSON(t *testing.T) 
 		CollectionItems: []model.CollectionPage{
 			{
 				Order: 0,
-				PageItems: []model.CollectionPageItem{
+				Rows: []model.CollectionRow{
 					{
-						Order:         0,
-						Type:          string(model.ContentBlockTypeRichText),
-						Content:       "# Welcome",
-						ContentFormat: model.ContentFormatMarkdown,
+						Columns: []model.CollectionColumn{
+							{
+								Items: []model.CollectionPageItem{
+									{
+										Order:         0,
+										Type:          string(model.ContentBlockTypeRichText),
+										Content:       "# Welcome",
+										ContentFormat: model.ContentFormatMarkdown,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -765,12 +776,20 @@ collection_items:
 		CollectionItems: []model.CollectionPage{
 			{
 				Order: 0,
-				PageItems: []model.CollectionPageItem{
+				Rows: []model.CollectionRow{
 					{
-						Order:         0,
-						Type:          string(model.ContentBlockTypeRichText),
-						Content:       "# Welcome",
-						ContentFormat: model.ContentFormatMarkdown,
+						Columns: []model.CollectionColumn{
+							{
+								Items: []model.CollectionPageItem{
+									{
+										Order:         0,
+										Type:          string(model.ContentBlockTypeRichText),
+										Content:       "# Welcome",
+										ContentFormat: model.ContentFormatMarkdown,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1083,5 +1102,82 @@ func TestNewCreateCollectionCommandWithExclusiveOptionMultiSelect(t *testing.T) 
 	writer.Flush()
 	if !strings.Contains(b.String(), "Collection created successfully!") {
 		t.Fatalf("expected success message; got %s", b.String())
+	}
+}
+
+// TestNewCreateCollectionCommandAcceptsV3RowsColumnsItems verifies that a
+// template using the native V3 rows/columns/items shape is accepted and sent
+// unchanged.
+func TestNewCreateCollectionCommandAcceptsV3RowsColumnsItems(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	tmpDir := t.TempDir()
+	templateFile := filepath.Join(tmpDir, "collection.json")
+	templateContent := fmt.Sprintf(`{
+  "workspace_id": "%s",
+  "name": "v3-native-collection",
+  "task_details": %s,
+  "collection_items": [
+    {
+      "order": 0,
+      "rows": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "order": 0,
+                  "type": "free_text",
+                  "description": "How was your experience completing this task?"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`, testWorkspaceID, taskDetails)
+
+	err := os.WriteFile(templateFile, []byte(templateContent), 0600)
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %s", err.Error())
+	}
+
+	var capturedPayload model.CreateAITaskBuilderCollection
+	c.EXPECT().
+		CreateAITaskBuilderCollection(gomock.Any()).
+		DoAndReturn(func(payload model.CreateAITaskBuilderCollection) (*client.CreateAITaskBuilderCollectionResponse, error) {
+			capturedPayload = payload
+			return &client.CreateAITaskBuilderCollectionResponse{
+				ID:          "collection-v3-123",
+				Name:        "v3-native-collection",
+				WorkspaceID: testWorkspaceID,
+			}, nil
+		})
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := collection.NewCreateCollectionCommand(c, writer)
+	cmd.SetArgs([]string{"-t", templateFile})
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error; got %s", err.Error())
+	}
+
+	if len(capturedPayload.CollectionItems) != 1 {
+		t.Fatalf("expected 1 collection item; got %d", len(capturedPayload.CollectionItems))
+	}
+
+	items := capturedPayload.CollectionItems[0].Rows[0].Columns[0].Items
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item; got %d", len(items))
+	}
+	if items[0].Type != string(model.InstructionTypeFreeText) {
+		t.Fatalf("expected item type 'free_text'; got '%s'", items[0].Type)
 	}
 }

--- a/cmd/collection/update.go
+++ b/cmd/collection/update.go
@@ -30,6 +30,9 @@ $ prolific collection update collec12345 -t collection.yaml
 Update a collection using a JSON config file:
 $ prolific collection update collec12345 -t collection.json
 
+Collection items use the rows -> columns -> items structure. The deprecated
+page_items shape is still accepted and converted automatically.
+
 Example YAML config file:
 ---
 name: My Updated Collection
@@ -39,10 +42,12 @@ task_details:
   task_steps: "<ol><li>Updated Step 1</li></ol>"
 collection_items:
   - order: 0
-    page_items:
-      - type: free_text
-        description: "What is your feedback?"
-        order: 0
+    rows:
+      - columns:
+          - items:
+              - type: free_text
+                description: "What is your feedback?"
+                order: 0
 
 Example JSON config file:
 {
@@ -54,10 +59,14 @@ Example JSON config file:
   },
   "collection_items": [{
     "order": 0,
-    "page_items": [{
-      "type": "free_text",
-      "description": "What is your feedback?",
-      "order": 0
+    "rows": [{
+      "columns": [{
+        "items": [{
+          "type": "free_text",
+          "description": "What is your feedback?",
+          "order": 0
+        }]
+      }]
     }]
   }]
 }`,
@@ -105,6 +114,10 @@ func validateTemplate(opts UpdateOptions) (model.UpdateCollection, error) {
 		return updatePayload, fmt.Errorf("unable to unmarshal config file: %s", err)
 	}
 
+	// Convert any deprecated v2 page_items input into the V3 rows/columns/items
+	// structure before validation so both shapes are accepted from template files.
+	updatePayload.NormaliseToV3()
+
 	if updatePayload.Name == "" {
 		return updatePayload, errors.New(ErrNameRequired)
 	}
@@ -114,12 +127,25 @@ func validateTemplate(opts UpdateOptions) (model.UpdateCollection, error) {
 		return updatePayload, errors.New(ErrCollectionItemsRequired)
 	}
 
-	// Validate that all pages have at least 1 item in page_items
+	// Validate that all pages have at least 1 item (across rows/columns)
 	for i, page := range updatePayload.CollectionItems {
-		if len(page.PageItems) == 0 {
-			return updatePayload, fmt.Errorf("page at index %d: %s", i, ErrPageItemsRequired)
+		if !pageHasItems(page) {
+			return updatePayload, fmt.Errorf("page at index %d: %s", i, ErrItemsRequired)
 		}
 	}
 
 	return updatePayload, nil
+}
+
+// pageHasItems reports whether a page contains at least one item in any of its
+// rows/columns.
+func pageHasItems(page model.Page) bool {
+	for _, row := range page.Rows {
+		for _, col := range row.Columns {
+			if len(col.Items) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/collection/update_test.go
+++ b/cmd/collection/update_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 const testUpdateCollectionID = "550e8400-e29b-41d4-a716-446655440000"
+const testPageID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 
 func TestNewUpdateCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -37,7 +38,7 @@ func TestNewUpdateCommand(t *testing.T) {
 
 func TestUpdateCollection(t *testing.T) {
 	collectionID := testUpdateCollectionID
-	pageID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	pageID := testPageID
 
 	tests := []struct {
 		name            string
@@ -94,25 +95,41 @@ collection_items:
 					{
 						BaseEntity: model.BaseEntity{ID: pageID},
 						Order:      0,
-						PageItems: []model.PageInstruction{
+						Rows: []model.Row{
 							{
-								Type:        model.InstructionTypeFreeText,
-								Description: "What is your name?",
-								Order:       0,
+								Columns: []model.Column{
+									{
+										Items: []model.PageInstruction{
+											{
+												Type:        model.InstructionTypeFreeText,
+												Description: "What is your name?",
+												Order:       0,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
 					{
 						Order: 1,
-						PageItems: []model.PageInstruction{
+						Rows: []model.Row{
 							{
-								Type:        model.InstructionTypeMultipleChoice,
-								Description: "How satisfied are you?",
-								Order:       0,
-								AnswerLimit: 1,
-								Options: []model.MultipleChoiceOption{
-									{Label: "Very Satisfied", Value: "5"},
-									{Label: "Satisfied", Value: "4"},
+								Columns: []model.Column{
+									{
+										Items: []model.PageInstruction{
+											{
+												Type:        model.InstructionTypeMultipleChoice,
+												Description: "How satisfied are you?",
+												Order:       0,
+												AnswerLimit: 1,
+												Options: []model.MultipleChoiceOption{
+													{Label: "Very Satisfied", Value: "5"},
+													{Label: "Satisfied", Value: "4"},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -159,11 +176,19 @@ Name: Collection With Pages
 					{
 						BaseEntity: model.BaseEntity{ID: pageID},
 						Order:      0,
-						PageItems: []model.PageInstruction{
+						Rows: []model.Row{
 							{
-								Type:        model.InstructionTypeFreeText,
-								Description: "Enter your feedback",
-								Order:       0,
+								Columns: []model.Column{
+									{
+										Items: []model.PageInstruction{
+											{
+												Type:        model.InstructionTypeFreeText,
+												Description: "Enter your feedback",
+												Order:       0,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -211,11 +236,19 @@ Name: JSON Updated Collection
 					{
 						BaseEntity: model.BaseEntity{ID: pageID},
 						Order:      0,
-						PageItems: []model.PageInstruction{
+						Rows: []model.Row{
 							{
-								Type:        model.InstructionTypeFreeText,
-								Description: "Enter your feedback",
-								Order:       0,
+								Columns: []model.Column{
+									{
+										Items: []model.PageInstruction{
+											{
+												Type:        model.InstructionTypeFreeText,
+												Description: "Enter your feedback",
+												Order:       0,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -281,7 +314,7 @@ collection_items:
 			mockReturn:     nil,
 			mockError:      nil,
 			expectedOutput: "",
-			expectedError:  "page at index 0: each page must have at least one item in page_items",
+			expectedError:  "page at index 0: each page must have at least one item",
 			skipMock:       true,
 		},
 		{
@@ -310,7 +343,7 @@ collection_items:
 			mockReturn:     nil,
 			mockError:      nil,
 			expectedOutput: "",
-			expectedError:  "page at index 1: each page must have at least one item in page_items",
+			expectedError:  "page at index 1: each page must have at least one item",
 			skipMock:       true,
 		},
 		{
@@ -341,11 +374,19 @@ collection_items:
 				CollectionItems: []model.Page{
 					{
 						Order: 0,
-						PageItems: []model.PageInstruction{
+						Rows: []model.Row{
 							{
-								Type:        model.InstructionTypeFreeText,
-								Description: "Valid page",
-								Order:       0,
+								Columns: []model.Column{
+									{
+										Items: []model.PageInstruction{
+											{
+												Type:        model.InstructionTypeFreeText,
+												Description: "Valid page",
+												Order:       0,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -373,11 +414,19 @@ collection_items:
 				CollectionItems: []model.Page{
 					{
 						Order: 0,
-						PageItems: []model.PageInstruction{
+						Rows: []model.Row{
 							{
-								Type:        model.InstructionTypeFreeText,
-								Description: "Valid page",
-								Order:       0,
+								Columns: []model.Column{
+									{
+										Items: []model.PageInstruction{
+											{
+												Type:        model.InstructionTypeFreeText,
+												Description: "Valid page",
+												Order:       0,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -553,7 +602,7 @@ func TestUpdateCollectionInvalidConfigFile(t *testing.T) {
 
 func TestUpdateCollectionExactPayload(t *testing.T) {
 	collectionID := testUpdateCollectionID
-	pageID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	pageID := testPageID
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -595,21 +644,29 @@ func TestUpdateCollectionExactPayload(t *testing.T) {
 					ID: pageID,
 				},
 				Order: 0,
-				PageItems: []model.PageInstruction{
+				Rows: []model.Row{
 					{
-						Type:                 model.InstructionTypeFreeText,
-						Description:          "Enter your feedback",
-						Order:                0,
-						PlaceholderTextInput: "Type here...",
-					},
-					{
-						Type:        model.InstructionTypeMultipleChoice,
-						Description: "Rate your experience",
-						Order:       1,
-						AnswerLimit: 1,
-						Options: []model.MultipleChoiceOption{
-							{Label: "Good", Value: "good"},
-							{Label: "Bad", Value: "bad"},
+						Columns: []model.Column{
+							{
+								Items: []model.PageInstruction{
+									{
+										Type:                 model.InstructionTypeFreeText,
+										Description:          "Enter your feedback",
+										Order:                0,
+										PlaceholderTextInput: "Type here...",
+									},
+									{
+										Type:        model.InstructionTypeMultipleChoice,
+										Description: "Rate your experience",
+										Order:       1,
+										AnswerLimit: 1,
+										Options: []model.MultipleChoiceOption{
+											{Label: "Good", Value: "good"},
+											{Label: "Bad", Value: "bad"},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -681,12 +738,20 @@ func TestUpdateCollectionPassesThroughContentFormat(t *testing.T) {
 		CollectionItems: []model.Page{
 			{
 				Order: 0,
-				PageItems: []model.PageInstruction{
+				Rows: []model.Row{
 					{
-						Type:          model.ContentBlockTypeRichText,
-						Content:       "# Welcome",
-						ContentFormat: model.ContentFormatMarkdown,
-						Order:         0,
+						Columns: []model.Column{
+							{
+								Items: []model.PageInstruction{
+									{
+										Type:          model.ContentBlockTypeRichText,
+										Content:       "# Welcome",
+										ContentFormat: model.ContentFormatMarkdown,
+										Order:         0,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -774,16 +839,24 @@ func TestUpdateCollectionWithExclusiveOptionMultiSelect(t *testing.T) {
 		CollectionItems: []model.Page{
 			{
 				Order: 0,
-				PageItems: []model.PageInstruction{
+				Rows: []model.Row{
 					{
-						Type:        model.InstructionTypeMultipleChoice,
-						Description: "Select all medications you are taking.",
-						Order:       0,
-						AnswerLimit: -1,
-						Options: []model.MultipleChoiceOption{
-							{Label: "Aspirin", Value: "aspirin"},
-							{Label: "Ibuprofen", Value: "ibuprofen"},
-							{Label: "None of the above", Value: "none", Exclusive: true},
+						Columns: []model.Column{
+							{
+								Items: []model.PageInstruction{
+									{
+										Type:        model.InstructionTypeMultipleChoice,
+										Description: "Select all medications you are taking.",
+										Order:       0,
+										AnswerLimit: -1,
+										Options: []model.MultipleChoiceOption{
+											{Label: "Aspirin", Value: "aspirin"},
+											{Label: "Ibuprofen", Value: "ibuprofen"},
+											{Label: "None of the above", Value: "none", Exclusive: true},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -814,5 +887,100 @@ func TestUpdateCollectionWithExclusiveOptionMultiSelect(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestUpdateCollectionAcceptsV3RowsColumnsItems verifies that a template using
+// the native V3 rows/columns/items shape is accepted and sent unchanged.
+func TestUpdateCollectionAcceptsV3RowsColumnsItems(t *testing.T) {
+	collectionID := testUpdateCollectionID
+	pageID := testPageID
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	configContent := `{
+  "name": "V3 Updated Collection",
+  "collection_items": [
+    {
+      "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+      "order": 0,
+      "rows": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "type": "free_text",
+                  "description": "Enter your feedback",
+                  "order": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+
+	expectedPayload := model.UpdateCollection{
+		Name: "V3 Updated Collection",
+		CollectionItems: []model.Page{
+			{
+				BaseEntity: model.BaseEntity{ID: pageID},
+				Order:      0,
+				Rows: []model.Row{
+					{
+						Columns: []model.Column{
+							{
+								Items: []model.PageInstruction{
+									{
+										Type:        model.InstructionTypeFreeText,
+										Description: "Enter your feedback",
+										Order:       0,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c.EXPECT().
+		UpdateCollection(collectionID, gomock.Eq(expectedPayload)).
+		Return(&model.Collection{
+			ID:        collectionID,
+			Name:      "V3 Updated Collection",
+			CreatedAt: time.Now(),
+			CreatedBy: "user123",
+			ItemCount: 1,
+		}, nil).
+		Times(1)
+
+	configFile := createTempConfigFile(t, configContent, ".json")
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := collection.NewUpdateCommand(c, writer)
+	cmd.SetArgs([]string{collectionID, "-t", configFile})
+	err := cmd.Execute()
+	writer.Flush()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedOutput := `Collection updated successfully
+ID: 550e8400-e29b-41d4-a716-446655440000
+Name: V3 Updated Collection
+`
+	actual := b.String()
+	if actual != expectedOutput {
+		t.Fatalf("expected output:\n'%s'\n\ngot:\n'%s'", expectedOutput, actual)
 	}
 }

--- a/docs/examples/collection.json
+++ b/docs/examples/collection.json
@@ -9,68 +9,76 @@
   "collection_items": [
     {
       "order": 0,
-      "page_items": [
+      "rows": [
         {
-          "order": 0,
-          "type": "rich_text",
-          "content": "# Welcome\nPlease read the **instructions** carefully before starting.",
-          "content_format": "markdown"
-        },
-        {
-          "order": 1,
-          "type": "free_text",
-          "description": "How was your experience completing this task?",
-          "validation": {
-            "type": "string",
-            "min": 10,
-            "max": 500
-          }
-        },
-        {
-          "order": 2,
-          "type": "multiple_choice",
-          "description": "Which option do you prefer?",
-          "options": [
+          "columns": [
             {
-              "label": "Response 1",
-              "value": "response1"
-            },
-            {
-              "label": "Response 2",
-              "value": "response2"
+              "items": [
+                {
+                  "order": 0,
+                  "type": "rich_text",
+                  "content": "# Welcome\nPlease read the **instructions** carefully before starting.",
+                  "content_format": "markdown"
+                },
+                {
+                  "order": 1,
+                  "type": "free_text",
+                  "description": "How was your experience completing this task?",
+                  "validation": {
+                    "type": "string",
+                    "min": 10,
+                    "max": 500
+                  }
+                },
+                {
+                  "order": 2,
+                  "type": "multiple_choice",
+                  "description": "Which option do you prefer?",
+                  "options": [
+                    {
+                      "label": "Response 1",
+                      "value": "response1"
+                    },
+                    {
+                      "label": "Response 2",
+                      "value": "response2"
+                    }
+                  ],
+                  "answer_limit": -1
+                },
+                {
+                  "order": 3,
+                  "type": "free_text_with_unit",
+                  "description": "What is your current weight?",
+                  "helper_text": "Please enter your weight as a number",
+                  "placeholder_text_input": "Enter weight",
+                  "unit_options": [
+                    {
+                      "label": "KG",
+                      "value": "kg",
+                      "validation": { "type": "number", "min": 20, "max": 300 }
+                    },
+                    {
+                      "label": "Pounds",
+                      "value": "lbs",
+                      "validation": { "type": "number", "min": 44, "max": 660 }
+                    }
+                  ],
+                  "default_unit": "kg",
+                  "unit_position": "suffix"
+                },
+                {
+                  "order": 4,
+                  "type": "file_upload",
+                  "description": "Please upload a photo of your receipt.",
+                  "accepted_file_types": [".jpg", ".png", ".pdf"],
+                  "max_file_size_mb": 5.0,
+                  "min_file_count": 1,
+                  "max_file_count": 3
+                }
+              ]
             }
-          ],
-          "answer_limit": -1
-        },
-        {
-          "order": 3,
-          "type": "free_text_with_unit",
-          "description": "What is your current weight?",
-          "helper_text": "Please enter your weight as a number",
-          "placeholder_text_input": "Enter weight",
-          "unit_options": [
-            {
-              "label": "KG",
-              "value": "kg",
-              "validation": { "type": "number", "min": 20, "max": 300 }
-            },
-            {
-              "label": "Pounds",
-              "value": "lbs",
-              "validation": { "type": "number", "min": 44, "max": 660 }
-            }
-          ],
-          "default_unit": "kg",
-          "unit_position": "suffix"
-        },
-        {
-          "order": 4,
-          "type": "file_upload",
-          "description": "Please upload a photo of your receipt.",
-          "accepted_file_types": [".jpg", ".png", ".pdf"],
-          "max_file_size_mb": 5.0,
-          "min_file_count": 1,
-          "max_file_count": 3
+          ]
         }
       ]
     }

--- a/docs/examples/collection.yaml
+++ b/docs/examples/collection.yaml
@@ -6,44 +6,46 @@ task_details:
   task_steps: "<ol><li>Example Step 1</li><li>Example Step 2</li></ol>"
 collection_items:
   - order: 0
-    page_items:
-      - order: 0
-        type: free_text
-        description: How was your experience completing this task?
-      - order: 1
-        type: multiple_choice
-        description: Which option do you prefer?
-        options:
-          - label: Response 1
-            value: response1
-          - label: Response 2
-            value: response2
-        answer_limit: -1
-      - order: 2
-        type: free_text_with_unit
-        description: What is your current weight?
-        helper_text: Please enter your weight as a number
-        placeholder_text_input: Enter weight
-        unit_options:
-          - label: KG
-            value: kg
-          - label: Pounds
-            value: lbs
-        default_unit: kg
-        unit_position: suffix
-      - order: 3
-        type: rich_text
-        content: |
-          # Welcome
-          Please read the **instructions** carefully before starting.
-        content_format: markdown
-      - order: 4
-        type: file_upload
-        description: Please upload a photo of your receipt.
-        accepted_file_types:
-          - .jpg
-          - .png
-          - .pdf
-        max_file_size_mb: 5.0
-        min_file_count: 1
-        max_file_count: 3
+    rows:
+      - columns:
+          - items:
+              - order: 0
+                type: free_text
+                description: How was your experience completing this task?
+              - order: 1
+                type: multiple_choice
+                description: Which option do you prefer?
+                options:
+                  - label: Response 1
+                    value: response1
+                  - label: Response 2
+                    value: response2
+                answer_limit: -1
+              - order: 2
+                type: free_text_with_unit
+                description: What is your current weight?
+                helper_text: Please enter your weight as a number
+                placeholder_text_input: Enter weight
+                unit_options:
+                  - label: KG
+                    value: kg
+                  - label: Pounds
+                    value: lbs
+                default_unit: kg
+                unit_position: suffix
+              - order: 3
+                type: rich_text
+                content: |
+                  # Welcome
+                  Please read the **instructions** carefully before starting.
+                content_format: markdown
+              - order: 4
+                type: file_upload
+                description: Please upload a photo of your receipt.
+                accepted_file_types:
+                  - .jpg
+                  - .png
+                  - .pdf
+                max_file_size_mb: 5.0
+                min_file_count: 1
+                max_file_count: 3

--- a/model/ai_task_builder.go
+++ b/model/ai_task_builder.go
@@ -172,10 +172,41 @@ type CreateAITaskBuilderCollection struct {
 	CollectionItems []CollectionPage `json:"collection_items" mapstructure:"collection_items"`
 }
 
-// CollectionPage represents a page in a collection containing instructions.
+// CollectionPage represents a page in a collection. In the V3 schema a page
+// nests its items as rows -> columns -> items. For backward compatibility the
+// CLI also accepts the deprecated v2 page_items shape in template files and
+// converts it to a single row/column on the wire (see NormaliseToV3).
 type CollectionPage struct {
-	Order     int                     `json:"order" mapstructure:"order"`
-	PageItems []CollectionInstruction `json:"page_items" mapstructure:"page_items"`
+	Order int             `json:"order" mapstructure:"order"`
+	Rows  []CollectionRow `json:"rows" mapstructure:"rows"`
+
+	// PageItems is the deprecated v2 input shape. It is parsed from template
+	// files for backward compatibility but never serialised to the API; it is
+	// converted into Rows by NormaliseToV3.
+	PageItems []CollectionPageItem `json:"-" mapstructure:"page_items"`
+}
+
+// CollectionRow represents a row within a collection page (V3 schema).
+type CollectionRow struct {
+	Columns []CollectionColumn `json:"columns" mapstructure:"columns"`
+}
+
+// CollectionColumn represents a column within a row, holding the page's items (V3 schema).
+type CollectionColumn struct {
+	Items []CollectionPageItem `json:"items" mapstructure:"items"`
+}
+
+// NormaliseToV3 converts any deprecated v2 page_items into the V3
+// rows -> columns -> items structure so the payload always serialises as V3.
+// Pages already expressed as rows are left untouched.
+func (c *CreateAITaskBuilderCollection) NormaliseToV3() {
+	for i := range c.CollectionItems {
+		page := &c.CollectionItems[i]
+		if len(page.Rows) == 0 && len(page.PageItems) > 0 {
+			page.Rows = []CollectionRow{{Columns: []CollectionColumn{{Items: page.PageItems}}}}
+		}
+		page.PageItems = nil
+	}
 }
 
 // CollectionPageItem represents an item within a collection page.

--- a/model/collection.go
+++ b/model/collection.go
@@ -127,11 +127,29 @@ type PageInstruction struct {
 	Caption string `json:"caption,omitempty" yaml:"caption,omitempty" mapstructure:"caption"`
 }
 
-// Page represents a single page within a collection.
+// Page represents a single page within a collection. In the V3 schema a page
+// nests its items as rows -> columns -> items. The deprecated v2 page_items
+// shape is still accepted from template files and converted to a single
+// row/column on the wire (see UpdateCollection.NormaliseToV3).
 type Page struct {
 	BaseEntity `yaml:",inline" mapstructure:",squash"`
-	Order      int               `json:"order" yaml:"order" mapstructure:"order"`
-	PageItems  []PageInstruction `json:"page_items" yaml:"page_items" mapstructure:"page_items"`
+	Order      int   `json:"order" yaml:"order" mapstructure:"order"`
+	Rows       []Row `json:"rows" yaml:"rows" mapstructure:"rows"`
+
+	// PageItems is the deprecated v2 input shape. It is parsed from template
+	// files for backward compatibility but never serialised to the API; it is
+	// converted into Rows by NormaliseToV3.
+	PageItems []PageInstruction `json:"-" yaml:"page_items,omitempty" mapstructure:"page_items"`
+}
+
+// Row represents a row within a collection page (V3 schema).
+type Row struct {
+	Columns []Column `json:"columns" yaml:"columns" mapstructure:"columns"`
+}
+
+// Column represents a column within a row, holding the page's items (V3 schema).
+type Column struct {
+	Items []PageInstruction `json:"items" yaml:"items" mapstructure:"items"`
 }
 
 // UpdateCollection represents the payload for updating a collection.
@@ -142,4 +160,17 @@ type UpdateCollection struct {
 	WorkspaceID     string       `json:"workspace_id,omitempty" yaml:"workspace_id,omitempty" mapstructure:"workspace_id"`
 	TaskDetails     *TaskDetails `json:"task_details,omitempty" yaml:"task_details,omitempty" mapstructure:"task_details"`
 	CollectionItems []Page       `json:"collection_items" yaml:"collection_items" mapstructure:"collection_items"`
+}
+
+// NormaliseToV3 converts any deprecated v2 page_items into the V3
+// rows -> columns -> items structure so the payload always serialises as V3.
+// Pages already expressed as rows are left untouched.
+func (u *UpdateCollection) NormaliseToV3() {
+	for i := range u.CollectionItems {
+		page := &u.CollectionItems[i]
+		if len(page.Rows) == 0 && len(page.PageItems) > 0 {
+			page.Rows = []Row{{Columns: []Column{{Items: page.PageItems}}}}
+		}
+		page.PageItems = nil
+	}
 }


### PR DESCRIPTION
## Summary

After **DCP-3117** (backend PR #793) migrated collections to the **V3 schema**, the data-collection API requires `collection_items` to nest items as `rows → columns → items`. The CLI still serialised the deprecated v2 `page_items` shape, so `collection create` — and `update`, which sends the same shape — failed with **HTTP 400** against any environment that has DCP-3117 deployed.

This makes the create/update payloads **emit V3 natively**, while keeping **backward compatibility** for existing v2 template files: a `page_items` template is parsed (`json:"-"`, never serialised) and converted to a single row/column via `NormaliseToV3()` before the request. The wire is always V3; existing template files keep working.

## Changes

- **model** (`ai_task_builder.go`, `collection.go`): add `Rows`/`Columns` types (`CollectionRow`/`CollectionColumn` and `Row`/`Column`), keep `page_items` as parse-only input, add `NormaliseToV3()`.
- **commands** (`create_collection.go`, `update.go`): normalise before the API call; validate items across rows/columns; help text shows V3 and notes v2 is still accepted.
- **constants**: shape-neutral validation error message.
- **docs/examples**: `collection.json` / `collection.yaml` converted to V3.
- **tests**: expected payloads → V3; v2 templates retained as live back-compat coverage; added V3-native input tests for both create and update.

## Verification

- `go test ./...` → **pass**
- `make lint` → no new findings (the 7 gosec findings are pre-existing on `main`, all in files outside this diff)
- **Live against orange dev**: v2 `page_items` create → 201 (`schema_version: 3`, reads back as `rows/columns/items`); v3-native create → 201; v2 `page_items` update → 200.