### PR TITLE
feat(DCP-3109): add batch sync command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -125,6 +125,8 @@ type API interface {
 	GetAITaskBuilderTasks(batchID string) (*GetAITaskBuilderTasksResponse, error)
 	InitiateBatchExport(batchID string) (*BatchExportResponse, error)
 	GetBatchExportStatus(batchID, exportID string) (*BatchExportResponse, error)
+	SyncAITaskBuilderBatch(batchID string) (*AITaskBuilderBatchSyncResponse, error)
+	GetAITaskBuilderBatchSyncStatus(batchID, syncID string) (*AITaskBuilderBatchSyncResponse, error)
 	GetAITaskBuilderDatasetStatus(datasetID string) (*GetAITaskBuilderDatasetStatusResponse, error)
 	GetAITaskBuilderDatasetUploadURL(datasetID, fileName string) (*GetAITaskBuilderDatasetUploadURLResponse, error)
 }
@@ -1406,6 +1408,46 @@ func (c *Client) GetBatchExportStatus(batchID, exportID string) (*BatchExportRes
 	var response BatchExportResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/batches/%s/export/%s", batchID, exportID)
+	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	if httpResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResponse.Body)
+		return nil, fmt.Errorf("unexpected status code %d: %s", httpResponse.StatusCode, string(body))
+	}
+
+	return &response, nil
+}
+
+// SyncAITaskBuilderBatch starts an async sync job that extends a batch with tasks
+// created from datapoints appended to its dataset since setup or the last sync.
+// Returns the created job (status "queued") including its sync_id.
+func (c *Client) SyncAITaskBuilderBatch(batchID string) (*AITaskBuilderBatchSyncResponse, error) {
+	var response AITaskBuilderBatchSyncResponse
+
+	url := fmt.Sprintf("/api/v1/data-collection/batches/%s/sync", batchID)
+	httpResponse, err := c.Execute(http.MethodPost, url, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	if httpResponse.StatusCode != http.StatusOK && httpResponse.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(httpResponse.Body)
+		return nil, fmt.Errorf("unexpected status code %d: %s", httpResponse.StatusCode, string(body))
+	}
+
+	return &response, nil
+}
+
+// GetAITaskBuilderBatchSyncStatus polls the status of an in-progress batch sync
+// job. Returns "queued", "processing", "complete" (with outcome counts), or
+// "failed" (with a reason).
+func (c *Client) GetAITaskBuilderBatchSyncStatus(batchID, syncID string) (*AITaskBuilderBatchSyncResponse, error) {
+	var response AITaskBuilderBatchSyncResponse
+
+	url := fmt.Sprintf("/api/v1/data-collection/batches/%s/syncs/%s", batchID, syncID)
 	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)

--- a/client/responses.go
+++ b/client/responses.go
@@ -418,6 +418,20 @@ type BatchExportResponse struct {
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
+// AITaskBuilderBatchSyncResponse is the response for both starting a batch sync
+// and polling its status. Status is one of "queued", "processing", "complete",
+// or "failed". The outcome counts are populated on completion; Reason is set on
+// failure.
+type AITaskBuilderBatchSyncResponse struct {
+	Status              string `json:"status"`
+	SyncID              string `json:"sync_id,omitempty"`
+	TasksCreated        int    `json:"tasks_created,omitempty"`
+	DatapointsProcessed int    `json:"datapoints_processed,omitempty"`
+	GroupsCreated       int    `json:"groups_created,omitempty"`
+	GroupsExpanded      int    `json:"groups_expanded,omitempty"`
+	Reason              string `json:"reason,omitempty"`
+}
+
 // CreateBonusPaymentsResponse is the response for creating bonus payments.
 // Monetary fields are returned by the API as floats in minor currency units
 // (e.g., 100.0 = £1.00). Divide by 100 before display via ui.RenderMoney().

--- a/cmd/aitaskbuilder/batch_sync.go
+++ b/cmd/aitaskbuilder/batch_sync.go
@@ -1,0 +1,161 @@
+package aitaskbuilder
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+)
+
+const (
+	batchSyncPollInterval   = 3 * time.Second
+	batchSyncDefaultTimeout = 10 * time.Minute
+	// batchSyncMaxPollErrors is how many consecutive polling errors are tolerated
+	// before giving up — polling should survive transient network/API blips.
+	batchSyncMaxPollErrors = 3
+
+	batchSyncStatusQueued     = "queued"
+	batchSyncStatusProcessing = "processing"
+	batchSyncStatusComplete   = "complete"
+	batchSyncStatusFailed     = "failed"
+)
+
+// batchSyncPollSleep is the sleep function used between sync status polls.
+// Replaced in tests via SetBatchSyncPollSleepForTesting to avoid real delays.
+var batchSyncPollSleep func(time.Duration) = time.Sleep
+
+// BatchSyncOptions holds the options for the batch sync command.
+type BatchSyncOptions struct {
+	Args    []string
+	Timeout time.Duration
+}
+
+// NewBatchSyncCommand creates a new `aitaskbuilder batch sync` command to extend
+// a batch with tasks for datapoints appended to its dataset since the last sync.
+func NewBatchSyncCommand(c client.API, w io.Writer) *cobra.Command {
+	var opts BatchSyncOptions
+
+	cmd := &cobra.Command{
+		Use:   "sync <batch-id>",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Sync a batch with datapoints appended to its dataset",
+		Long: `Sync a batch with datapoints appended to its dataset
+
+Starts an asynchronous sync job that extends an already set-up batch with
+tasks created from datapoints added to its attached dataset since setup or
+the last sync. This command polls until the job reaches a terminal state and
+then reports how much work was materialised.`,
+		Example: `
+Sync a batch and wait for completion:
+
+$ prolific aitaskbuilder batch sync 5f8e3c2a-1d4b-4e6f-9a7c-2b0d8f3e1c5a
+
+Sync with a shorter timeout:
+
+$ prolific aitaskbuilder batch sync 5f8e3c2a-1d4b-4e6f-9a7c-2b0d8f3e1c5a --timeout 2m
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+
+			if len(opts.Args) < 1 || opts.Args[0] == "" {
+				return errors.New(ErrBatchIDRequired)
+			}
+
+			return syncBatch(c, opts, w)
+		},
+	}
+
+	cmd.Flags().DurationVarP(&opts.Timeout, "timeout", "t", batchSyncDefaultTimeout,
+		"Maximum time to wait for the sync to complete")
+
+	return cmd
+}
+
+func syncBatch(c client.API, opts BatchSyncOptions, w io.Writer) error {
+	batchID := opts.Args[0]
+
+	fmt.Fprintf(w, "Starting sync for batch %s...\n", batchID)
+
+	// Step 1: POST to start the sync job.
+	initResult, err := c.SyncAITaskBuilderBatch(batchID)
+	if err != nil {
+		return fmt.Errorf("error: %s", err)
+	}
+
+	// A sync could in principle come back already terminal; handle both here.
+	switch initResult.Status {
+	case batchSyncStatusComplete:
+		return reportSyncComplete(initResult, batchID, w)
+	case batchSyncStatusFailed:
+		return fmt.Errorf("error: sync failed for batch %s: %s", batchID, syncFailureReason(initResult))
+	case batchSyncStatusQueued, batchSyncStatusProcessing:
+		// fall through to polling
+	default:
+		return fmt.Errorf("error: unexpected sync status %q for batch %s", initResult.Status, batchID)
+	}
+
+	syncID := initResult.SyncID
+	if syncID == "" {
+		return fmt.Errorf("error: sync started but no sync ID was returned for batch %s", batchID)
+	}
+
+	// Step 2: Poll GET until complete or failed, tolerating transient errors.
+	deadline := time.Now().Add(opts.Timeout)
+	consecutiveErrors := 0
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("error: sync timed out after %s for batch %s", opts.Timeout, batchID)
+		}
+
+		fmt.Fprint(w, ".")
+		// Cap the sleep at the time remaining so --timeout bounds the total wait rather than being
+		// overshot by a whole poll interval.
+		sleep := batchSyncPollInterval
+		if remaining := time.Until(deadline); remaining < sleep {
+			sleep = remaining
+		}
+		batchSyncPollSleep(sleep)
+
+		pollResult, err := c.GetAITaskBuilderBatchSyncStatus(batchID, syncID)
+		if err != nil {
+			consecutiveErrors++
+			if consecutiveErrors >= batchSyncMaxPollErrors {
+				return fmt.Errorf("error: %s", err)
+			}
+			// Transient blip — keep polling until the deadline or the error cap.
+			continue
+		}
+		consecutiveErrors = 0
+
+		switch pollResult.Status {
+		case batchSyncStatusComplete:
+			return reportSyncComplete(pollResult, batchID, w)
+		case batchSyncStatusFailed:
+			return fmt.Errorf("error: sync failed for batch %s: %s", batchID, syncFailureReason(pollResult))
+		case batchSyncStatusQueued, batchSyncStatusProcessing:
+			// continue polling
+		default:
+			return fmt.Errorf("error: unexpected sync status %q for batch %s", pollResult.Status, batchID)
+		}
+	}
+}
+
+func reportSyncComplete(r *client.AITaskBuilderBatchSyncResponse, batchID string, w io.Writer) error {
+	fmt.Fprintf(w, "\nSync complete for batch %s.\n", batchID)
+	fmt.Fprintf(w, "  Datapoints processed: %d\n", r.DatapointsProcessed)
+	fmt.Fprintf(w, "  Tasks created:        %d\n", r.TasksCreated)
+	fmt.Fprintf(w, "  Groups created:       %d\n", r.GroupsCreated)
+	fmt.Fprintf(w, "  Groups expanded:      %d\n", r.GroupsExpanded)
+	return nil
+}
+
+func syncFailureReason(r *client.AITaskBuilderBatchSyncResponse) string {
+	if r.Reason != "" {
+		return r.Reason
+	}
+	return "no reason provided"
+}

--- a/cmd/aitaskbuilder/batch_sync_sleep_test.go
+++ b/cmd/aitaskbuilder/batch_sync_sleep_test.go
@@ -1,0 +1,15 @@
+package aitaskbuilder
+
+import "time"
+
+// SetBatchSyncPollSleepForTesting replaces the poll sleep function for the duration of a
+// test. Call the returned function (typically via defer) to restore the original.
+//
+// This file is compiled only during `go test` and is intentionally in
+// package aitaskbuilder (not aitaskbuilder_test) so that it can access unexported
+// variables while still being callable from external test packages.
+func SetBatchSyncPollSleepForTesting(f func(time.Duration)) func() {
+	prev := batchSyncPollSleep
+	batchSyncPollSleep = f
+	return func() { batchSyncPollSleep = prev }
+}

--- a/cmd/aitaskbuilder/batch_sync_test.go
+++ b/cmd/aitaskbuilder/batch_sync_test.go
@@ -1,0 +1,279 @@
+package aitaskbuilder_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/aitaskbuilder"
+	"github.com/prolific-oss/cli/mock_client"
+)
+
+const testSyncID = "sync-job-uuid-789"
+
+func TestNewBatchSyncCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	var buf bytes.Buffer
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, &buf)
+
+	if cmd.Use != "sync <batch-id>" {
+		t.Fatalf("expected use: sync <batch-id>; got %s", cmd.Use)
+	}
+	if cmd.Short != "Sync a batch with datapoints appended to its dataset" {
+		t.Fatalf("unexpected short description: %s", cmd.Short)
+	}
+}
+
+func TestBatchSyncCommandRequiresBatchID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	var buf bytes.Buffer
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, &buf)
+
+	if err := cmd.RunE(cmd, []string{}); err == nil {
+		t.Fatal("expected error for missing batch ID, got nil")
+	}
+}
+
+// TestBatchSyncCommandPollingToComplete covers the normal async flow: POST
+// returns "queued", then GET returns "processing" and finally "complete".
+func TestBatchSyncCommandPollingToComplete(t *testing.T) {
+	defer aitaskbuilder.SetBatchSyncPollSleepForTesting(func(time.Duration) {})()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{Status: "queued", SyncID: testSyncID}, nil).
+		Times(1)
+
+	gomock.InOrder(
+		mockClient.EXPECT().
+			GetAITaskBuilderBatchSyncStatus(gomock.Eq(testBatchID), gomock.Eq(testSyncID)).
+			Return(&client.AITaskBuilderBatchSyncResponse{Status: "processing"}, nil).
+			Times(1),
+		mockClient.EXPECT().
+			GetAITaskBuilderBatchSyncStatus(gomock.Eq(testBatchID), gomock.Eq(testSyncID)).
+			Return(&client.AITaskBuilderBatchSyncResponse{
+				Status:              "complete",
+				TasksCreated:        5,
+				DatapointsProcessed: 5,
+				GroupsCreated:       2,
+				GroupsExpanded:      1,
+			}, nil).
+			Times(1),
+	)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+
+	err := cmd.RunE(cmd, []string{testBatchID})
+	w.Flush()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := b.String()
+	for _, want := range []string{"Sync complete", "Tasks created:", "5", "Groups expanded:", "1"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected output to contain %q, got: %s", want, output)
+		}
+	}
+}
+
+// TestBatchSyncCommandImmediateComplete covers the POST returning a terminal
+// "complete" status straight away, so no polling happens.
+func TestBatchSyncCommandImmediateComplete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{
+			Status:              "complete",
+			TasksCreated:        3,
+			DatapointsProcessed: 3,
+			GroupsCreated:       1,
+			GroupsExpanded:      0,
+		}, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+
+	err := cmd.RunE(cmd, []string{testBatchID})
+	w.Flush()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !strings.Contains(b.String(), "Sync complete") {
+		t.Errorf("expected completion summary, got: %s", b.String())
+	}
+}
+
+// TestBatchSyncCommandImmediateFailed covers the POST returning a terminal
+// "failed" status straight away.
+func TestBatchSyncCommandImmediateFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{
+			Status: "failed",
+			Reason: "batch must be in READY status to sync",
+		}, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+
+	err := cmd.RunE(cmd, []string{testBatchID})
+	w.Flush()
+	if err == nil {
+		t.Fatal("expected error for failed status, got nil")
+	}
+	if !strings.Contains(err.Error(), "batch must be in READY status to sync") {
+		t.Errorf("expected error to include the failure reason, got: %v", err)
+	}
+}
+
+func TestBatchSyncCommandFailedStatus(t *testing.T) {
+	defer aitaskbuilder.SetBatchSyncPollSleepForTesting(func(time.Duration) {})()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{Status: "queued", SyncID: testSyncID}, nil).
+		Times(1)
+
+	mockClient.EXPECT().
+		GetAITaskBuilderBatchSyncStatus(gomock.Eq(testBatchID), gomock.Eq(testSyncID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{
+			Status: "failed",
+			Reason: "dataset has an import in progress",
+		}, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+
+	err := cmd.RunE(cmd, []string{testBatchID})
+	w.Flush()
+	if err == nil {
+		t.Fatal("expected error for failed status, got nil")
+	}
+	if !strings.Contains(err.Error(), "dataset has an import in progress") {
+		t.Errorf("expected error to include the failure reason, got: %v", err)
+	}
+}
+
+func TestBatchSyncCommandInitiateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(nil, errors.New("network error")).
+		Times(1)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+
+	if err := cmd.RunE(cmd, []string{testBatchID}); err == nil {
+		t.Fatal("expected error on client failure, got nil")
+	}
+}
+
+// TestBatchSyncCommandTransientPollErrorRecovers verifies the poll loop tolerates
+// a transient error and continues to a successful terminal state.
+func TestBatchSyncCommandTransientPollErrorRecovers(t *testing.T) {
+	defer aitaskbuilder.SetBatchSyncPollSleepForTesting(func(time.Duration) {})()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{Status: "queued", SyncID: testSyncID}, nil).
+		Times(1)
+
+	gomock.InOrder(
+		mockClient.EXPECT().
+			GetAITaskBuilderBatchSyncStatus(gomock.Eq(testBatchID), gomock.Eq(testSyncID)).
+			Return(nil, errors.New("temporary network blip")).
+			Times(1),
+		mockClient.EXPECT().
+			GetAITaskBuilderBatchSyncStatus(gomock.Eq(testBatchID), gomock.Eq(testSyncID)).
+			Return(&client.AITaskBuilderBatchSyncResponse{Status: "complete"}, nil).
+			Times(1),
+	)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+
+	err := cmd.RunE(cmd, []string{testBatchID})
+	w.Flush()
+	if err != nil {
+		t.Fatalf("expected transient error to be tolerated, got: %v", err)
+	}
+	if !strings.Contains(b.String(), "Sync complete") {
+		t.Errorf("expected sync to complete after transient error, got: %s", b.String())
+	}
+}
+
+func TestBatchSyncCommandTimeout(t *testing.T) {
+	defer aitaskbuilder.SetBatchSyncPollSleepForTesting(func(time.Duration) {})()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_client.NewMockAPI(ctrl)
+
+	mockClient.EXPECT().
+		SyncAITaskBuilderBatch(gomock.Eq(testBatchID)).
+		Return(&client.AITaskBuilderBatchSyncResponse{Status: "queued", SyncID: testSyncID}, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	cmd := aitaskbuilder.NewBatchSyncCommand(mockClient, w)
+	// A zero timeout means the deadline is already in the past by the first poll
+	// check, so the loop exits before calling GET.
+	if err := cmd.Flags().Set("timeout", "0s"); err != nil {
+		t.Fatalf("failed to set timeout flag: %v", err)
+	}
+
+	err := cmd.RunE(cmd, []string{testBatchID})
+	w.Flush()
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+}

--- a/cmd/aitaskbuilder/batches.go
+++ b/cmd/aitaskbuilder/batches.go
@@ -19,6 +19,7 @@ func NewBatchesCommand(client client.API, w io.Writer) *cobra.Command {
 		NewBatchCreateCommand(client, w),
 		NewBatchUpdateCommand(client, w),
 		NewBatchExportCommand(client, w),
+		NewBatchSyncCommand(client, w),
 		NewBatchInstructionsCommand(client, w),
 		NewBatchSetupCommand(client, w),
 		NewGetBatchCommand(client, w),

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -450,6 +450,21 @@ func (mr *MockAPIMockRecorder) GetAITaskBuilderBatchStatus(batchID interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatchStatus", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatchStatus), batchID)
 }
 
+// GetAITaskBuilderBatchSyncStatus mocks base method.
+func (m *MockAPI) GetAITaskBuilderBatchSyncStatus(batchID, syncID string) (*client.AITaskBuilderBatchSyncResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAITaskBuilderBatchSyncStatus", batchID, syncID)
+	ret0, _ := ret[0].(*client.AITaskBuilderBatchSyncResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAITaskBuilderBatchSyncStatus indicates an expected call of GetAITaskBuilderBatchSyncStatus.
+func (mr *MockAPIMockRecorder) GetAITaskBuilderBatchSyncStatus(batchID, syncID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAITaskBuilderBatchSyncStatus", reflect.TypeOf((*MockAPI)(nil).GetAITaskBuilderBatchSyncStatus), batchID, syncID)
+}
+
 // GetAITaskBuilderBatches mocks base method.
 func (m *MockAPI) GetAITaskBuilderBatches(workspaceID string) (*client.GetAITaskBuilderBatchesResponse, error) {
 	m.ctrl.T.Helper()
@@ -1120,6 +1135,21 @@ func (m *MockAPI) SetupAITaskBuilderBatch(batchID, datasetID string, tasksPerGro
 func (mr *MockAPIMockRecorder) SetupAITaskBuilderBatch(batchID, datasetID, tasksPerGroup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupAITaskBuilderBatch", reflect.TypeOf((*MockAPI)(nil).SetupAITaskBuilderBatch), batchID, datasetID, tasksPerGroup)
+}
+
+// SyncAITaskBuilderBatch mocks base method.
+func (m *MockAPI) SyncAITaskBuilderBatch(batchID string) (*client.AITaskBuilderBatchSyncResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncAITaskBuilderBatch", batchID)
+	ret0, _ := ret[0].(*client.AITaskBuilderBatchSyncResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SyncAITaskBuilderBatch indicates an expected call of SyncAITaskBuilderBatch.
+func (mr *MockAPIMockRecorder) SyncAITaskBuilderBatch(batchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncAITaskBuilderBatch", reflect.TypeOf((*MockAPI)(nil).SyncAITaskBuilderBatch), batchID)
 }
 
 // TestStudy mocks base method.


### PR DESCRIPTION

<img width="793" height="195" alt="Screenshot 2026-07-11 at 11 35 25" src="https://github.com/user-attachments/assets/f27749fd-e5e2-41ca-a884-37eef3a6cf09" />

(there was nothing to sync, but just making sure the flow works 😅 )
## Context

Batches created in AI Task Builder can be extended after setup: datapoints appended to the attached dataset are turned into new tasks via an async **sync** job (`POST /batches/{id}/sync` → poll `GET /batches/{id}/syncs/{sync_id}`). This adds CLI support so researchers can trigger and monitor a sync from the terminal.

Implements DCP-3109.

## What it does

`prolific aitaskbuilder batch sync <batch-id>`:
- Starts the sync job and polls its status until a terminal state.
- Tolerates transient polling errors (retries up to a small cap) rather than aborting on the first blip.
- Prints a summary on success (datapoints processed, tasks created, groups created/expanded).
- Returns the failure reason and exits non-zero if the job fails or the wait times out.
- `--timeout` (default 10m) bounds how long it waits.

Follows the existing `batch export` initiate-then-poll pattern (injectable poll-sleep for tests, deadline-based timeout, status switch).

## Notes for review

- **CI `make test`**: the contract test validates the client against the *live* `docs.prolific.com/openapi.yaml` and is currently failing on a pre-existing stale coverage-table entry (`get-user-identity`) that also fails on `main` — unrelated to this change. `make lint`, `go build`, and the `aitaskbuilder`/`client` package tests pass.
- **Contract/SIT coverage for sync is deferred**: the sync endpoints aren't in the published OpenAPI spec yet, so a contract-table entry (and a real-environment SIT) can only be added once the AITB sync API is deployed and documented. Worth a follow-up ticket.