### PR TITLE
fix: remove stale get-user-identity coverage-table entry

### DIFF
--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -340,7 +340,6 @@ var operations = []operation{
 
 	// Users
 	{operationID: "get-user", call: func(c *client.Client) { c.GetMe() }},
-	{operationID: "get-user-identity", skip: "OUTOFSCOPE: no CLI command for retrieving user identity"},
 	{operationID: "create-test-participant-for-researcher", call: func(c *client.Client) {
 		c.CreateTestParticipant("test@example.com")
 	}},


### PR DESCRIPTION
## Summary
- PR #449 added a coverage-table entry for operationId `get-user-identity` in `contract_test/contract_test.go`, but that operation does not exist in the live spec at docs.prolific.com/openapi.yaml (only `get-user` does).
- `TestAPICoverage` correctly flags this as a stale entry, which currently fails CI on `main` and on every branch based on it (e.g. #447).

## Test plan
- [x] `go test ./contract_test/...` passes locally
- [ ] CI `Go` build passes on this PR