### PR TITLE
chore(DCP-3225): bump go toolchain to 1.26.5 to patch symlink vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prolific-oss/cli
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // MIT


### PR DESCRIPTION
## Summary

Snyk flagged CVE-2026-39822 (CVSS 8.5, High) in the Go standard library's `os` package: on Unix, opening a path inside an `os.Root` that ends in `/` whose final component is a symlink can escape the intended root. This is a toolchain-level vulnerability, not a third-party dependency, so the fix is bumping the `go` directive in `go.mod` from `1.26.3` to `1.26.5` (the patched release).

## Why this approach

The `Dockerfile`'s build image was already bumped to `golang:1.27rc2-alpine` by Dependabot in a prior merge (already past the fixed version for this CVE), and CI's `go-version: [1.26.x]` in `go.yml` floats to the latest matching patch automatically. The one place still pinning the vulnerable version was `go.mod`'s `go` directive itself, which Dependabot doesn't touch. `go mod tidy` confirms `go.sum` is unaffected — this is a pure toolchain version bump, no dependency changes.

## Rollback

Revert this commit to restore `go 1.26.3` in `go.mod`. No other files change.