### PR TITLE
feat: add reward-recommendations command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+### Reward Recommendations
+
+- Add reward-recommendations command
+
 ## 1.1.0
 
 ### AI Task Builder

--- a/client/client.go
+++ b/client/client.go
@@ -89,6 +89,8 @@ type API interface {
 
 	GetFilters() (*ListFiltersResponse, error)
 
+	GetRewardRecommendations(workspaceID, currency string, screenerIDs []string) (*RewardRecommendationsResponse, error)
+
 	GetFilterSets(workspaceID string, limit, offset int) (*ListFilterSetsResponse, error)
 	GetFilterSet(ID string) (*model.FilterSet, error)
 	CreateFilterSet(filterSet model.CreateFilterSet) (*CreateFilterSetResponse, error)
@@ -929,6 +931,28 @@ func (c *Client) GetFilters() (*ListFiltersResponse, error) {
 	_, err := c.Execute(http.MethodGet, url, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	}
+
+	return &response, nil
+}
+
+// GetRewardRecommendations will return Prolific's recommended reward-per-hour
+// rates for a workspace and currency, optionally scoped to a set of screener
+// filter IDs.
+func (c *Client) GetRewardRecommendations(workspaceID, currency string, screenerIDs []string) (*RewardRecommendationsResponse, error) {
+	var response RewardRecommendationsResponse
+
+	query := url.Values{}
+	query.Set("workspace_id", workspaceID)
+	query.Set("currency", currency)
+	if len(screenerIDs) > 0 {
+		query.Set("screener_ids", strings.Join(screenerIDs, ","))
+	}
+
+	requestURL := "/api/v1/reward-recommendations/?" + query.Encode()
+	_, err := c.Execute(http.MethodGet, requestURL, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", requestURL, err)
 	}
 
 	return &response, nil

--- a/client/responses.go
+++ b/client/responses.go
@@ -83,6 +83,11 @@ type ListFiltersResponse struct {
 	*JSONAPIMeta
 }
 
+// RewardRecommendationsResponse is the response for the reward
+// recommendations endpoint. The API guarantees the first item is the most
+// recent set of rates.
+type RewardRecommendationsResponse []model.RewardRecommendation
+
 // TransitionSubmissionResponse is the response for transitioning a submission.
 type TransitionSubmissionResponse struct {
 	ID          string  `json:"id"`

--- a/cmd/rewardrecommendations/reward_recommendations.go
+++ b/cmd/rewardrecommendations/reward_recommendations.go
@@ -1,0 +1,107 @@
+package rewardrecommendations
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// allowedCurrencies are the ISO 4217 currency codes Prolific's reward
+// recommendations endpoint supports.
+var allowedCurrencies = []string{"USD", "GBP"}
+
+// Options are the options for the reward recommendations command.
+type Options struct {
+	WorkspaceID string
+	Currency    string
+	ScreenerIDs []string
+}
+
+// NewCommand creates a new `reward-recommendations` command to calculate
+// recommended participant reward rates.
+func NewCommand(commandName string, c client.API, w io.Writer) *cobra.Command {
+	var opts Options
+
+	cmd := &cobra.Command{
+		Use:   commandName,
+		Short: "Calculate recommended participant reward rates",
+		Long: `Calculate reward recommendations
+
+Returns Prolific's recommended minimum and "good" hourly reward rates for a
+workspace and currency, optionally scoped to a set of screener filter IDs
+(e.g. custom group filter IDs) you plan to apply to your study.
+
+We recommend calling this before creating a draft study, then using the
+returned rates to determine your study's reward.`,
+		Example: `
+Calculate reward recommendations for a workspace in GBP
+$ prolific reward-recommendations -w 6261321e223a605c7a4f7623 -c GBP
+
+Scope the recommendation to specific screeners
+$ prolific reward-recommendations -w 6261321e223a605c7a4f7623 -c GBP -s mandarin -s spanish
+
+Use the workspace set in your config file
+$ prolific reward-recommendations -c USD
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := render(c, opts, w)
+			if err != nil {
+				return fmt.Errorf("error: %s", err)
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.WorkspaceID, "workspace", "w", viper.GetString("workspace"), "The ID of the workspace you'll be creating the study in.")
+	flags.StringVarP(&opts.Currency, "currency", "c", "", fmt.Sprintf("The currency for the recommendation. One of: %s", strings.Join(allowedCurrencies, ", ")))
+	flags.StringArrayVarP(&opts.ScreenerIDs, "screener-id", "s", nil, "A screener/filter ID to scope the recommendation to. Can be specified multiple times.")
+
+	return cmd
+}
+
+// render will fetch and display the reward recommendation.
+func render(c client.API, opts Options, w io.Writer) error {
+	if opts.WorkspaceID == "" {
+		return errors.New("please provide a workspace ID")
+	}
+
+	if opts.Currency == "" {
+		return errors.New("please provide a currency")
+	}
+
+	if !slices.Contains(allowedCurrencies, opts.Currency) {
+		return fmt.Errorf("currency must be one of: %s", strings.Join(allowedCurrencies, ", "))
+	}
+
+	response, err := c.GetRewardRecommendations(opts.WorkspaceID, opts.Currency, opts.ScreenerIDs)
+	if err != nil {
+		return err
+	}
+
+	if len(*response) == 0 {
+		return errors.New("no reward recommendations returned")
+	}
+
+	// The API guarantees the first item is the most recent set of rates.
+	recommendation := (*response)[0]
+
+	toCurrency := func(amount int) float64 {
+		return float64(amount) / 100
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 1, 2, ' ', 0)
+	fmt.Fprintf(tw, "Currency:\t%s\n", recommendation.Currency)
+	fmt.Fprintf(tw, "Minimum reward per hour:\t%.2f\n", toCurrency(recommendation.MinRewardPerHour))
+	fmt.Fprintf(tw, "Recommended reward per hour:\t%.2f\n", toCurrency(recommendation.RecommendedRewardPerHour))
+
+	return tw.Flush()
+}

--- a/cmd/rewardrecommendations/reward_recommendations_test.go
+++ b/cmd/rewardrecommendations/reward_recommendations_test.go
@@ -1,0 +1,198 @@
+package rewardrecommendations_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/rewardrecommendations"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/spf13/viper"
+)
+
+func TestNewCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, os.Stdout)
+
+	if cmd.Use != "reward-recommendations" {
+		t.Fatalf("expected use: reward-recommendations; got %s", cmd.Use)
+	}
+
+	if cmd.Short != "Calculate recommended participant reward rates" {
+		t.Fatalf("expected short: Calculate recommended participant reward rates; got %s", cmd.Short)
+	}
+}
+
+func TestNewCommandCallsAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := client.RewardRecommendationsResponse{
+		{
+			Currency:                 "GBP",
+			MinRewardPerHour:         900,
+			RecommendedRewardPerHour: 1200,
+		},
+	}
+
+	c.
+		EXPECT().
+		GetRewardRecommendations("abc123", "GBP", []string{"mandarin", "spanish"}).
+		Return(&response, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, writer)
+	_ = cmd.Flags().Set("workspace", "abc123")
+	_ = cmd.Flags().Set("currency", "GBP")
+	_ = cmd.Flags().Set("screener-id", "mandarin")
+	_ = cmd.Flags().Set("screener-id", "spanish")
+	_ = cmd.RunE(cmd, []string{})
+
+	writer.Flush()
+
+	expected := `Currency:                     GBP
+Minimum reward per hour:      9.00
+Recommended reward per hour:  12.00
+`
+	actual := b.String()
+	if actual != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%s'\n", expected, actual)
+	}
+}
+
+func TestNewCommandUsesViperWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	viper.Set("workspace", "viper-workspace-id")
+	t.Cleanup(func() { viper.Reset() })
+
+	response := client.RewardRecommendationsResponse{
+		{Currency: "USD", MinRewardPerHour: 1200, RecommendedRewardPerHour: 1500},
+	}
+
+	c.
+		EXPECT().
+		GetRewardRecommendations("viper-workspace-id", "USD", []string(nil)).
+		Return(&response, nil).
+		Times(1)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, writer)
+	_ = cmd.Flags().Set("currency", "USD")
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error; got %s", err)
+	}
+}
+
+func TestNewCommandErrorsWithNoWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	viper.Reset()
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, os.Stdout)
+	_ = cmd.Flags().Set("currency", "USD")
+	err := cmd.RunE(cmd, []string{})
+
+	expected := "error: please provide a workspace ID"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%v'\n", expected, err)
+	}
+}
+
+func TestNewCommandErrorsWithNoCurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, os.Stdout)
+	_ = cmd.Flags().Set("workspace", "abc123")
+	err := cmd.RunE(cmd, []string{})
+
+	expected := "error: please provide a currency"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%v'\n", expected, err)
+	}
+}
+
+func TestNewCommandErrorsWithUnsupportedCurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, os.Stdout)
+	_ = cmd.Flags().Set("workspace", "abc123")
+	_ = cmd.Flags().Set("currency", "EUR")
+	err := cmd.RunE(cmd, []string{})
+
+	expected := "error: currency must be one of: USD, GBP"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%v'\n", expected, err)
+	}
+}
+
+func TestNewCommandHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	errorMessage := "something went wrong"
+
+	c.
+		EXPECT().
+		GetRewardRecommendations("abc123", "USD", []string(nil)).
+		Return(nil, errors.New(errorMessage)).
+		Times(1)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, os.Stdout)
+	_ = cmd.Flags().Set("workspace", "abc123")
+	_ = cmd.Flags().Set("currency", "USD")
+	err := cmd.RunE(cmd, []string{})
+
+	expected := fmt.Sprintf("error: %s", errorMessage)
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%v'\n", expected, err)
+	}
+}
+
+func TestNewCommandErrorsWithEmptyResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	response := client.RewardRecommendationsResponse{}
+
+	c.
+		EXPECT().
+		GetRewardRecommendations("abc123", "USD", []string(nil)).
+		Return(&response, nil).
+		Times(1)
+
+	cmd := rewardrecommendations.NewCommand("reward-recommendations", c, os.Stdout)
+	_ = cmd.Flags().Set("workspace", "abc123")
+	_ = cmd.Flags().Set("currency", "USD")
+	err := cmd.RunE(cmd, []string{})
+
+	expected := "error: no reward recommendations returned"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected\n'%s'\ngot\n'%v'\n", expected, err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prolific-oss/cli/cmd/participantgroup"
 	"github.com/prolific-oss/cli/cmd/project"
 	"github.com/prolific-oss/cli/cmd/researcher"
+	"github.com/prolific-oss/cli/cmd/rewardrecommendations"
 	"github.com/prolific-oss/cli/cmd/study"
 	"github.com/prolific-oss/cli/cmd/submission"
 	"github.com/prolific-oss/cli/cmd/survey"
@@ -85,6 +86,7 @@ func NewRootCommand() *cobra.Command {
 		participantgroup.NewParticipantCommand(&client, w),
 		project.NewProjectCommand(&client, w),
 		researcher.NewResearcherCommand(&client, w),
+		rewardrecommendations.NewCommand("reward-recommendations", &client, w),
 		study.NewListCommand("studies", &client, w),
 		study.NewStudyCommand(&client, w),
 		submission.NewSubmissionCommand(&client, w),

--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -312,7 +312,9 @@ var operations = []operation{
 	}},
 
 	// Reward Recommendations
-	{operationID: "calculate-reward-recommendations", skip: "OUTOFSCOPE: reward recommendations not needed in CLI"},
+	{operationID: "calculate-reward-recommendations", call: func(c *client.Client) {
+		c.GetRewardRecommendations("ws-id", "GBP", []string{"mandarin", "spanish"})
+	}},
 
 	// Well-known endpoints
 	{operationID: "get-study-jwks", skip: "OUTOFSCOPE: JWKS endpoint not needed in CLI"},

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -825,6 +825,21 @@ func (mr *MockAPIMockRecorder) GetProjects(workspaceID, limit, offset interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockAPI)(nil).GetProjects), workspaceID, limit, offset)
 }
 
+// GetRewardRecommendations mocks base method.
+func (m *MockAPI) GetRewardRecommendations(workspaceID, currency string, screenerIDs []string) (*client.RewardRecommendationsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRewardRecommendations", workspaceID, currency, screenerIDs)
+	ret0, _ := ret[0].(*client.RewardRecommendationsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRewardRecommendations indicates an expected call of GetRewardRecommendations.
+func (mr *MockAPIMockRecorder) GetRewardRecommendations(workspaceID, currency, screenerIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRewardRecommendations", reflect.TypeOf((*MockAPI)(nil).GetRewardRecommendations), workspaceID, currency, screenerIDs)
+}
+
 // GetStudies mocks base method.
 func (m *MockAPI) GetStudies(status, projectID string) (*client.ListStudiesResponse, error) {
 	m.ctrl.T.Helper()

--- a/model/reward_recommendation.go
+++ b/model/reward_recommendation.go
@@ -1,0 +1,11 @@
+package model
+
+// RewardRecommendation holds Prolific's recommended reward-per-hour rates
+// for a given workspace, currency, and (optionally) a set of screener
+// filter IDs. MinRewardPerHour and RecommendedRewardPerHour are both in the
+// hundredth subunit of Currency (e.g. cents for USD, pence for GBP).
+type RewardRecommendation struct {
+	Currency                 string `json:"currency"`
+	MinRewardPerHour         int    `json:"min_reward_per_hour"`
+	RecommendedRewardPerHour int    `json:"recommended_reward_per_hour"`
+}

--- a/scripts/changelog/main.go
+++ b/scripts/changelog/main.go
@@ -355,6 +355,7 @@ var areaMapping = []struct {
 	{"cmd/filters/", "Filters"},
 	{"cmd/filtersets/", "Filters"},
 	{"cmd/requirements/", "Requirements"},
+	{"cmd/rewardrecommendations/", "Reward Recommendations"},
 	{"cmd/user/", "User"},
 	{"model/", "Core"},
 	{"client/", "Core"},
@@ -446,6 +447,7 @@ var areaOrder = []string{
 	"Hooks",
 	"Filters",
 	"Requirements",
+	"Reward Recommendations",
 	"User",
 	"Core",
 }

--- a/scripts/changelog/main_test.go
+++ b/scripts/changelog/main_test.go
@@ -474,6 +474,7 @@ func TestAreaForFiles(t *testing.T) {
 		{"majority wins", []string{"cmd/study/list.go", "cmd/study/get.go", "cmd/workspace/list.go"}, "Study"},
 		{"model and client map to Core", []string{"model/study.go", "client/client.go"}, "Core"},
 		{"filters and filtersets both map to Filters", []string{"cmd/filters/list.go", "cmd/filtersets/list.go"}, "Filters"},
+		{"reward recommendations files", []string{"cmd/rewardrecommendations/reward_recommendations.go"}, "Reward Recommendations"},
 		{"unrecognised files return empty", []string{"README.md", "Makefile"}, ""},
 		{"mixed unrecognised and user-facing keeps user-facing", []string{"scripts/foo.sh", "cmd/study/list.go"}, "Study"},
 		{"empty file list returns empty", []string{}, ""},


### PR DESCRIPTION
Prolific's /api/v1/reward-recommendations/ endpoint was explicitly out of scope in the CLI's own contract tests, leaving no way to get recommended reward rates without the web app. Adds:

- prolific reward-recommendations -w <workspace> -c <USD|GBP> [-s <screener-id>]...
- GetRewardRecommendations on the client.API interface
- RewardRecommendationsResponse / model.RewardRecommendation types
- A real contract test case (was previously skipped OUTOFSCOPE), verified passing against the live openapi.yaml spec

Verified against the live API and docs.prolific.com's published reference for this endpoint, not just the OpenAPI spec.