### PR TITLE
fix(BUZZ-258): ratings output parity across json/csv/table

### DIFF
--- a/cmd/feedback/ratings.go
+++ b/cmd/feedback/ratings.go
@@ -1,7 +1,6 @@
 package feedback
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,7 +28,10 @@ func NewRatingsCommand(c client.API, w io.Writer) *cobra.Command {
 		Long: `View aggregate participant ratings for a study
 
 Shows the average clarity, ease and fairness ratings and the number of
-responses contributing to each rating.`,
+responses contributing to each rating.
+
+JSON, CSV and table output all render the same rating rows, so the rating
+names and response counts match whichever format you pick.`,
 		Example: `
 View aggregate ratings for a study
 $ prolific feedback ratings -s 63c123af913a974f87e8e7fc
@@ -51,9 +53,8 @@ $ prolific feedback ratings -s 63c123af913a974f87e8e7fc --csv`,
 
 			switch shared.ResolveFormat(opts.Output) {
 			case "json":
-				encoder := json.NewEncoder(w)
-				encoder.SetIndent("", "  ")
-				if err := encoder.Encode(ratings); err != nil {
+				renderer := ui.JSONRenderer[feedbackui.RatingSummary]{}
+				if err := renderer.Render(feedbackui.NewRatingSummaries(*ratings), w); err != nil {
 					return fmt.Errorf("error: %s", err)
 				}
 			case "csv":

--- a/cmd/feedback/ratings_test.go
+++ b/cmd/feedback/ratings_test.go
@@ -52,7 +52,7 @@ func TestNewRatingsCommandOutputFormats(t *testing.T) {
 		{
 			name:     "JSON",
 			flag:     "json",
-			expected: []string{`"clarity_rating"`, `"average_rating": 4.5`, `"total_count": 2`},
+			expected: []string{`"rating": "clarity"`, `"average_rating": 4.5`, `"total_count": 2`, `"rating": "ease"`, `"rating": "fairness"`},
 		},
 		{
 			name:     "CSV",

--- a/ui/feedback/ratings.go
+++ b/ui/feedback/ratings.go
@@ -1,6 +1,11 @@
 package feedback
 
-import "github.com/prolific-oss/cli/client"
+import (
+	"sort"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/model"
+)
 
 // RatingFields are the fields shown in study ratings table and CSV output.
 const RatingFields = "Rating,Average,Responses"
@@ -16,22 +21,66 @@ var studyRatingIDs = []studyRatingID{
 	{ID: "fairness_rating", Label: "fairness"},
 }
 
-// RatingItem is the presentation model for one aggregate study rating.
+// RatingSummary is one aggregate study rating. Every output format renders from
+// this so JSON, CSV and table agree on labels and on which ratings appear.
+type RatingSummary struct {
+	Rating    string   `json:"rating"`
+	Average   *float64 `json:"average_rating"`
+	Responses int      `json:"total_count"`
+}
+
+// RatingItem is the text-formatted view of a RatingSummary, used by the table
+// and CSV renderers which read fields by name via reflection.
 type RatingItem struct {
 	Rating    string
 	Average   string
 	Responses int
 }
 
-// NewRatingItems converts the ratings response map into deterministic rows.
-func NewRatingItems(ratings client.StudyRatingsResponse) []RatingItem {
-	items := make([]RatingItem, 0, len(studyRatingIDs))
+// NewRatingSummaries flattens the ratings response into deterministic rows: the
+// known ratings in display order, then any rating the API has added since, so a
+// new key is never silently dropped from one output format.
+func NewRatingSummaries(ratings client.StudyRatingsResponse) []RatingSummary {
+	summaries := make([]RatingSummary, 0, len(ratings))
+	seen := make(map[string]bool, len(studyRatingIDs))
+
 	for _, rating := range studyRatingIDs {
-		summary := ratings[rating.ID]
+		seen[rating.ID] = true
+		summaries = append(summaries, newRatingSummary(rating.Label, ratings[rating.ID]))
+	}
+
+	extra := make([]string, 0)
+	for id := range ratings {
+		if !seen[id] {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(extra)
+
+	for _, id := range extra {
+		summaries = append(summaries, newRatingSummary(id, ratings[id]))
+	}
+
+	return summaries
+}
+
+func newRatingSummary(label string, rating model.StudyRating) RatingSummary {
+	return RatingSummary{
+		Rating:    label,
+		Average:   rating.AverageRating,
+		Responses: rating.TotalCount,
+	}
+}
+
+// NewRatingItems converts the ratings response into display-ready rows.
+func NewRatingItems(ratings client.StudyRatingsResponse) []RatingItem {
+	summaries := NewRatingSummaries(ratings)
+	items := make([]RatingItem, 0, len(summaries))
+	for _, summary := range summaries {
 		items = append(items, RatingItem{
-			Rating:    rating.Label,
-			Average:   formatRating(summary.AverageRating),
-			Responses: summary.TotalCount,
+			Rating:    summary.Rating,
+			Average:   formatRating(summary.Average),
+			Responses: summary.Responses,
 		})
 	}
 	return items

--- a/ui/feedback/ratings_test.go
+++ b/ui/feedback/ratings_test.go
@@ -34,3 +34,54 @@ func TestNewRatingItems(t *testing.T) {
 		t.Fatalf("unexpected fairness row: %#v", items[2])
 	}
 }
+
+func TestNewRatingSummariesSharesLabelsWithItems(t *testing.T) {
+	average := 4.5
+	ratings := client.StudyRatingsResponse{
+		"clarity_rating": model.StudyRating{AverageRating: &average, TotalCount: 3},
+	}
+
+	summaries := feedback.NewRatingSummaries(ratings)
+	items := feedback.NewRatingItems(ratings)
+
+	if len(summaries) != len(items) {
+		t.Fatalf("expected summaries and items to cover the same ratings, got %d and %d", len(summaries), len(items))
+	}
+
+	for i, summary := range summaries {
+		if summary.Rating != items[i].Rating {
+			t.Fatalf("row %d label mismatch: %q vs %q", i, summary.Rating, items[i].Rating)
+		}
+		if summary.Responses != items[i].Responses {
+			t.Fatalf("row %d response count mismatch: %d vs %d", i, summary.Responses, items[i].Responses)
+		}
+	}
+
+	if summaries[0].Average == nil || *summaries[0].Average != average {
+		t.Fatalf("expected clarity average %v, got %#v", average, summaries[0].Average)
+	}
+
+	if summaries[2].Average != nil {
+		t.Fatalf("expected missing fairness average to stay nil, got %#v", summaries[2].Average)
+	}
+}
+
+func TestNewRatingSummariesIncludesUnknownRatings(t *testing.T) {
+	ratings := client.StudyRatingsResponse{
+		"enjoyment_rating": model.StudyRating{TotalCount: 7},
+	}
+
+	summaries := feedback.NewRatingSummaries(ratings)
+	if len(summaries) != 4 {
+		t.Fatalf("expected the unknown rating to be appended, got %d rows", len(summaries))
+	}
+
+	if summaries[3].Rating != "enjoyment_rating" || summaries[3].Responses != 7 {
+		t.Fatalf("unexpected trailing row: %#v", summaries[3])
+	}
+
+	items := feedback.NewRatingItems(ratings)
+	if len(items) != len(summaries) {
+		t.Fatalf("table/CSV rows dropped the unknown rating: %d vs %d", len(items), len(summaries))
+	}
+}


### PR DESCRIPTION
Follow-up to #472 — output-format parity fix for `feedback ratings`.

## Problem

`feedback ratings` registers `-j/--json`, `-c/--csv`, `-t/--table` (so all the flags are there), but the formats did not agree:

| | JSON (before) | CSV / table |
|---|---|---|
| rating names | `clarity_rating`, `difficulty_rating`, `fairness_rating` | `clarity`, `ease`, `fairness` |
| unknown API rating key | shown | **silently dropped** |

Two causes:

1. `--json` dumped the raw `client.StudyRatingsResponse` map through a bespoke `json.NewEncoder`, bypassing `ui.JSONRenderer` that every other command uses. So JSON carried API key names while CSV/table carried the display labels — `difficulty_rating` vs `ease` in particular.
2. `NewRatingItems` iterated only the three hardcoded ids in `studyRatingIDs`, so if the API ever returns a fourth rating it appears in JSON but never in CSV or table.

Anything scripting `--json` therefore got different field names to `--csv`, from the same command.

## Fix

All three formats now render from a single ordered source, `NewRatingSummaries`:

- known ratings first, in display order, then any unrecognised key appended (sorted, so output stays deterministic) — a new API rating can no longer show up in one format and vanish from another
- `RatingSummary` keeps `Average` as `*float64` so JSON emits `null`/number rather than the `"-"` placeholder that table and CSV want
- `RatingItem` (the reflection-friendly, string-formatted view used by `TableRenderer`/`CsvRenderer`) now derives from the same summaries
- `--json` goes through `ui.JSONRenderer[RatingSummary]`, so the bespoke encoder block is gone and the command matches the shared renderer pattern

`ratings --json` output shape changes from an object keyed by API rating id to an array of rating rows — consistent with every other JSON output in the CLI, and unreleased, so no back-compat concern.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./...` passes
- updated the `--json` assertion in `cmd/feedback/ratings_test.go` (was asserting the old raw-map shape)
- added `TestNewRatingSummariesSharesLabelsWithItems` (labels + counts identical across formats) and `TestNewRatingSummariesIncludesUnknownRatings` (unknown key survives into CSV/table)