### PR TITLE
Begin refactoring Client Execute with fluent interface pattern. Related to #37

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -292,7 +292,7 @@ func (c *Client) GetMe() (*MeResponse, error) {
 	var response MeResponse
 
 	url := "/api/v1/users/me"
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}
@@ -636,7 +636,7 @@ func (c *Client) GetHookEventTypes() (*ListHookEventTypesResponse, error) {
 	var response ListHookEventTypesResponse
 
 	url := "/api/v1/hooks/event-types/"
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}
@@ -927,6 +927,24 @@ func (c *Client) RemoveParticipantGroupMembers(groupID string, participantIDs []
 	return &response, nil
 }
 
+func (c *Client) AddParticipantGroupMembers(groupID string, participantIDs []string) (*ViewParticipantGroupResponse, error) {
+	payload := AddParticipantGroupMembersPayload{
+		ParticipantIDs: participantIDs,
+	}
+	var response ViewParticipantGroupResponse
+
+	url := fmt.Sprintf("/api/v1/participant-groups/%s/participants/", groupID)
+	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add participants to group %s: %s", groupID, err)
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unable to add participants to group %s, status code: %v", groupID, httpResponse.StatusCode)
+	}
+
+	return &response, nil
+}
+
 // CreateTestParticipant creates a test participant for the researcher with the given email.
 func (c *Client) CreateTestParticipant(email string) (*CreateTestParticipantResponse, error) {
 	var response CreateTestParticipantResponse
@@ -953,7 +971,7 @@ func (c *Client) GetFilters() (*ListFiltersResponse, error) {
 	var response ListFiltersResponse
 
 	url := "/api/v1/filters/"
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -292,9 +292,8 @@ func (c *Client) GetMe() (*MeResponse, error) {
 	var response MeResponse
 
 	url := "/api/v1/users/me"
-	_, err := c.ExecuteBuilder().Get(url, &response)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	if _, err := c.ExecuteBuilder().Get(url, &response); err != nil {
+		return nil, err
 	}
 
 	return &response, nil
@@ -636,9 +635,8 @@ func (c *Client) GetHookEventTypes() (*ListHookEventTypesResponse, error) {
 	var response ListHookEventTypesResponse
 
 	url := "/api/v1/hooks/event-types/"
-	_, err := c.ExecuteBuilder().Get(url, &response)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	if _, err := c.ExecuteBuilder().Get(url, &response); err != nil {
+		return nil, err
 	}
 
 	return &response, nil
@@ -971,9 +969,8 @@ func (c *Client) GetFilters() (*ListFiltersResponse, error) {
 	var response ListFiltersResponse
 
 	url := "/api/v1/filters/"
-	_, err := c.ExecuteBuilder().Get(url, &response)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+	if _, err := c.ExecuteBuilder().Get(url, &response); err != nil {
+		return nil, err
 	}
 
 	return &response, nil

--- a/client/execute_builder.go
+++ b/client/execute_builder.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type ExecuteBuilder struct {
+	client           *Client
+	method           string
+	url              string
+	body             any
+	response         any
+	expectedStatuses []int
+}
+
+func (c *Client) ExecuteBuilder() *ExecuteBuilder {
+	return &ExecuteBuilder{client: c}
+}
+
+func (b *ExecuteBuilder) Get(url string, response any) (*http.Response, error) {
+	return b.GetRequest(url).Status(200).Decode(response).Execute()
+}
+
+func (b *ExecuteBuilder) GetRequest(url string) *ExecuteBuilder {
+	b.method = http.MethodGet
+	b.url = url
+	return b
+}
+
+func (b *ExecuteBuilder) Body(v any) *ExecuteBuilder {
+	b.body = v
+	return b
+}
+
+func (b *ExecuteBuilder) Decode(v any) *ExecuteBuilder {
+	b.response = v
+	return b
+}
+
+func (b *ExecuteBuilder) Status(statuses ...int) *ExecuteBuilder {
+	b.expectedStatuses = statuses
+	return b
+}
+
+func (b *ExecuteBuilder) Execute() (*http.Response, error) {
+	httpResponse, err := b.client.Execute(b.method, b.url, b.body, b.response)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to fulfil request %s: %s", b.url, err)
+	}
+
+	// Check if the status code is one of the accepted ones
+	for _, status := range b.expectedStatuses {
+		if httpResponse.StatusCode == status {
+			return httpResponse, nil
+		}
+	}
+
+	// Status didn't match — read body for error message
+	body, _ := io.ReadAll(httpResponse.Body)
+	return nil, fmt.Errorf("unexpected status code %d: %s", httpResponse.StatusCode, string(body))
+}

--- a/client/execute_builder.go
+++ b/client/execute_builder.go
@@ -20,12 +20,22 @@ func (c *Client) ExecuteBuilder() *ExecuteBuilder {
 }
 
 func (b *ExecuteBuilder) Get(url string, response any) (*http.Response, error) {
-	return b.GetRequest(url).Status(200).Decode(response).Execute()
+	return b.GetRequest(url).Status(http.StatusOK).Decode(response).Execute()
 }
 
 func (b *ExecuteBuilder) GetRequest(url string) *ExecuteBuilder {
-	b.method = http.MethodGet
+	return b.newRequest(http.MethodGet, url)
+}
+
+// newRequest clears any state carried over from a previous request, so a
+// builder that is held and reused cannot send an earlier request's body or
+// accept an earlier request's statuses.
+func (b *ExecuteBuilder) newRequest(method, url string) *ExecuteBuilder {
+	b.method = method
 	b.url = url
+	b.body = nil
+	b.response = nil
+	b.expectedStatuses = nil
 	return b
 }
 

--- a/client/execute_builder_test.go
+++ b/client/execute_builder_test.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testResponse is a simple struct for decoding test responses
+type testResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestExecuteBuilderGet(t *testing.T) {
+	// Create a mock server that returns JSON
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(testResponse{ID: "123", Name: "test"}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token", // satisfies the token check in Execute()
+	}
+
+	var resp testResponse
+	_, err := c.ExecuteBuilder().Get("/some-path", &resp)
+	require.NoError(t, err)
+	require.Equal(t, "123", resp.ID)
+	require.Equal(t, "test", resp.Name)
+}
+
+func TestExecuteBuilderGetReturnsErrorOnHTTPFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token", // satisfies the token check in Execute()
+	}
+
+	var resp testResponse
+	_, err := c.ExecuteBuilder().Get("/some-path", &resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to fulfil request")
+}
+
+// A 202 is a success as far as Client.Execute is concerned (it only errors on
+// 4xx and above), so this exercises the builder's own status check rather than
+// the error path inside Execute.
+func TestExecuteBuilderGetReturnsErrorOnUnexpectedSuccessStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(testResponse{ID: "123", Name: "test"}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	var resp testResponse
+	_, err := c.ExecuteBuilder().Get("/some-path", &resp)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected status code 202")
+}
+
+func TestExecuteBuilderExecuteAcceptsAConfiguredStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(testResponse{ID: "123", Name: "test"}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	var resp testResponse
+	httpResponse, err := c.ExecuteBuilder().
+		GetRequest("/some-path").
+		Status(http.StatusCreated).
+		Decode(&resp).
+		Execute()
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, httpResponse.StatusCode)
+	require.Equal(t, "123", resp.ID)
+}

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -77,6 +77,11 @@ type RemoveParticipantGroupMembersPayload struct {
 	ParticipantIDs []string `json:"participant_ids"`
 }
 
+// AddParticipantGroupMembersPayload represents the JSON payload for adding participants to a group.
+type AddParticipantGroupMembersPayload struct {
+	ParticipantIDs []string `json:"participant_ids"`
+}
+
 // DatasetSchemaField describes a single field in a dataset schema.
 type DatasetSchemaField struct {
 	Type  string `json:"type"`


### PR DESCRIPTION
Addresses repetitive, boiiler platey code in around client.exectue using the fluent interface pattern.

This PR starts the execute builder and uses it to refactor the two simplest client Get methods.

As the other methods are refactored in line with this pattern, it should dramatically reduce repetitive code and provide a cleaner, more readable way of chaining actions.