### PR TITLE
feat(DCT-199): support display_position in aitaskbuilder batch commands

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -44,6 +44,14 @@ func TestFormatBatchErrorBody(t *testing.T) {
 			body:     []byte(`{"type":"INVALID_BATCH_ITEMS","issues":[{"page":0,"row":0,"column":0,"item":0,"type":"free_text","message":"description is required"},{"page":1,"row":2,"column":1,"item":3,"type":"multiple_choice","message":"answer_limit exceeds number of options"}]}`),
 			expected: "batch_items validation failed:\n  Page 1, Row 1, Column 1, Item 1 (free_text): description is required\n  Page 2, Row 3, Column 2, Item 4 (multiple_choice): answer_limit exceeds number of options",
 		},
+		{
+			// A non-content-block item (e.g. an instruction) on a display_position "intro"/"outro"
+			// page — see DISPLAY_POSITION_CONTENT_ONLY_MESSAGE in data-collection-tool. No `field`
+			// is set for this issue type, so it should format the same as any other fieldless issue.
+			name:     "INVALID_BATCH_ITEMS with display_position content-only violation",
+			body:     []byte(`{"type":"INVALID_BATCH_ITEMS","issues":[{"page":0,"row":0,"column":0,"item":0,"type":"free_text","message":"Pages with display_position \"intro\" or \"outro\" may only contain image or rich_text content blocks"}]}`),
+			expected: `batch_items validation failed:` + "\n" + `  Page 1, Row 1, Column 1, Item 1 (free_text): Pages with display_position "intro" or "outro" may only contain image or rich_text content blocks`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/aitaskbuilder/batch_create.go
+++ b/cmd/aitaskbuilder/batch_create.go
@@ -38,6 +38,12 @@ Optionally, supply batch_items to define the participant task layout as a struct
 JSON schema (pages → rows → columns → items). Provide batch_items from a file with
 -f or as an inline JSON string with -j. See docs/examples/batch-items.json for an example.
 
+Each page may also set display_position to "intro" or "outro" to render once — before
+or after the repeating task loop — instead of once per datapoint. Omit the field (or
+set it to "body") for the default repeating behaviour. intro/outro pages may only
+contain rich_text/image content blocks, not instructions or dataset_field refs. See
+docs/examples/batch-items-with-intro-outro.json for an example.
+
 Set --auto-sync to automatically add new dataset datapoints to the batch as they
 arrive; it defaults to false.`,
 		Example: `
@@ -49,6 +55,9 @@ $ prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <datase
 
 Create a batch with inline batch_items JSON:
 $ prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <dataset_id> --task-name "Task" --task-introduction "Intro" --task-steps "Steps" -j '[{"rows":[{"columns":[{"items":[{"type":"free_text","description":"Describe your observations."}]}]}]}]'
+
+Create a batch with intro/outro pages that render once instead of once per datapoint:
+$ prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <dataset_id> --task-name "Task" --task-introduction "Intro" --task-steps "Steps" -j '[{"display_position":"intro","rows":[{"columns":[{"items":[{"type":"rich_text","content":"<p>Welcome!</p>"}]}]}]},{"rows":[{"columns":[{"items":[{"type":"free_text","description":"Describe your observations."}]}]}]},{"display_position":"outro","rows":[{"columns":[{"items":[{"type":"rich_text","content":"<p>Thank you!</p>"}]}]}]}]'
 
 Create a batch with auto-sync enabled:
 $ prolific aitaskbuilder batch create -n "My Batch" -w <workspace_id> -d <dataset_id> --task-name "Task" --task-introduction "Intro" --task-steps "Steps" --auto-sync

--- a/cmd/aitaskbuilder/batch_update.go
+++ b/cmd/aitaskbuilder/batch_update.go
@@ -45,6 +45,12 @@ batch_items can be set from a file (-f) or inline JSON (-j), or cleared with
 --clear-batch-items. Clearing batch_items also deletes all associated instructions
 and content blocks for the batch.
 
+Each page may also set display_position to "intro" or "outro" to render once — before
+or after the repeating task loop — instead of once per datapoint. Omit the field (or
+set it to "body") for the default repeating behaviour. intro/outro pages may only
+contain rich_text/image content blocks, not instructions or dataset_field refs. See
+docs/examples/batch-items-with-intro-outro.json for an example.
+
 --auto-sync enables automatic sync; --no-auto-sync disables it. They are mutually exclusive.`,
 		Example: `
 Update a batch name:
@@ -61,6 +67,9 @@ $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -n
 
 Set batch_items from a file:
 $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -f batch-items.json
+
+Add an intro page that renders once instead of once per datapoint:
+$ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 -j '[{"display_position":"intro","rows":[{"columns":[{"items":[{"type":"rich_text","content":"<p>Welcome! Please review each response carefully before answering.</p>"}]}]}]},{"rows":[{"columns":[{"items":[{"type":"free_text","description":"Please describe your observations."},{"type":"multiple_choice","description":"How confident are you in your answer?","answer_limit":1,"options":[{"label":"Very confident","value":"very_confident"},{"label":"Somewhat confident","value":"somewhat_confident"},{"label":"Not confident","value":"not_confident"}]}]}]}]}]'
 
 Clear batch_items:
 $ prolific aitaskbuilder batch update -b 497f6eca-6276-4993-bfeb-53cbbbba6f08 --clear-batch-items

--- a/docs/examples/batch-items-with-intro-outro.json
+++ b/docs/examples/batch-items-with-intro-outro.json
@@ -1,0 +1,62 @@
+[
+  {
+    "display_position": "intro",
+    "rows": [
+      {
+        "columns": [
+          {
+            "items": [
+              {
+                "type": "rich_text",
+                "content": "<p>Welcome! Please review each response carefully before answering.</p>"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "columns": [
+          {
+            "items": [
+              {
+                "type": "free_text",
+                "description": "Please describe your observations."
+              },
+              {
+                "type": "multiple_choice",
+                "description": "How confident are you in your answer?",
+                "answer_limit": 1,
+                "options": [
+                  { "label": "Very confident", "value": "very_confident" },
+                  { "label": "Somewhat confident", "value": "somewhat_confident" },
+                  { "label": "Not confident", "value": "not_confident" }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "display_position": "outro",
+    "rows": [
+      {
+        "columns": [
+          {
+            "items": [
+              {
+                "type": "rich_text",
+                "content": "<p>Thank you for completing this task.</p>"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Consumes the `display_position` field added to AI Task Builder batch pages by the DCT-193/194/195 backend work — the piece that lets researchers/QA actually exercise intro/outro pages through this CLI, ahead of prolific_web_client#7589 (DCT-200).

`batch_items` is opaque passthrough JSON client-side (`parseBatchItemsInput`) — no Go type validation happens here, so `display_position` needed no code change. Adds `docs/examples/batch-items-with-intro-outro.json` and updates `batch create`/`batch update` help text (including a self-contained inline `-j` example, matching the existing inline-JSON example style) so researchers can discover the field. Also adds a `client_test.go` case confirming the new server-side content-only validation error formats sensibly through `formatBatchErrorBody`'s existing generic issue handling — no special-casing needed.

Collection support (`model.CollectionPage`/`model.Page` gaining a typed `DisplayPosition` field, plus local validation) was originally in scope here too, but that's been reverted — see [DCT-226](https://github.com/prolific-oss/data-collection-tool/pull/890). `display_position` has zero participant-facing effect on Collection pages (they already render exactly once per run regardless), so there's nothing for the CLI to expose there.

## Test plan

- Full unit suite, `go vet`, and `golangci-lint` all pass.
- Manual end-to-end validation against the orange environment: created a V4 dataset + 3-datapoint CSV, created a batch from `docs/examples/batch-items-with-intro-outro.json`, ran `batch setup --tasks-per-group 3`, and confirmed via `batch preview` in the browser (against a hosted orange FE build of prolific_web_client#7589) that intro/rubric pages each render once, the rating page renders once per task, the progress bar totals correctly, and back-navigation crosses phase boundaries correctly with no lost form state.
- Reproduced the originally-reported bug directly: the same batch shape with no `display_position` set produces 9 total pages across 3 datapoints instead of 5, with welcome/rubric content repeating 3 times each — confirming the field's fix is real and necessary.