### PR TITLE
fix(SI-1524): fetch full history when checking out homebrew-tap

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -166,6 +166,7 @@ jobs:
         with:
           repository: prolific-oss/homebrew-tap
           token: ${{ secrets.REPO_CONTENTS_WRITE }}
+          fetch-depth: 0
 
       - name: Bump formula
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 1.2.1
+
+### Core
+
+- Releases now automatically bump the version in the [prolific-oss/homebrew-tap](https://github.com/prolific-oss/homebrew-tap) formula, opening a PR there
+
 ## 1.2.0
 
 ### Reward Recommendations


### PR DESCRIPTION
actions/checkout defaults to a shallow clone, so the pinned bump-script commit wasn't reachable and the job failed. Adds fetch-depth: 0 to that checkout step, and bumps the changelog for 1.2.1.