### PR TITLE
refactor(DCT-266): migrate study/collection client methods to ExecuteBuilder

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -355,7 +355,7 @@ func (c *Client) GetStudies(status, projectID string) (*ListStudiesResponse, err
 		}
 	}
 
-	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func (c *Client) GetSubmissions(ID string, limit, offset int) (*ListSubmissionsR
 	var response ListSubmissionsResponse
 
 	url := fmt.Sprintf("/api/v1/studies/%s/submissions/?limit=%v&offset=%v", ID, limit, offset)
-	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func (c *Client) GetCampaigns(workspaceID string, limit, offset int) (*ListCampa
 	var response ListCampaignsResponse
 
 	url := fmt.Sprintf("/api/v1/campaigns/?workspace_id=%s&limit=%v&offset=%v", workspaceID, limit, offset)
-	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +500,7 @@ func (c *Client) GetCollections(workspaceID string, limit, offset int) (*ListCol
 	var response ListCollectionsResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections?workspace_id=%s&limit=%v&offset=%v", workspaceID, limit, offset)
-	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -546,7 +546,7 @@ func (c *Client) GetCollectionExportStatus(collectionID, exportID string) (*Coll
 	var response CollectionExportResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections/%s/export/%s", collectionID, exportID)
-	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -632,9 +632,9 @@ func (c *Client) GetHooks(workspaceID string, enabled bool, limit, offset int) (
 		limit,
 		offset,
 	)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -658,9 +658,9 @@ func (c *Client) GetHookSecrets(workspaceID string) (*ListSecretsResponse, error
 	var response ListSecretsResponse
 
 	url := fmt.Sprintf("/api/v1/hooks/secrets/?workspace_id=%s", workspaceID)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -671,13 +671,14 @@ func (c *Client) CreateHookSecret(payload CreateSecretPayload) (*model.Secret, e
 	var response model.Secret
 
 	const url = "/api/v1/hooks/secrets/"
-	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Status(http.StatusCreated).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("unable to create hook secret: %v", httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil
@@ -688,9 +689,9 @@ func (c *Client) GetEvents(subscriptionID string, limit, offset int) (*ListHookE
 	var response ListHookEventsResponse
 
 	url := fmt.Sprintf("/api/v1/hooks/subscriptions/%s/events/?limit=%v&offset=%v", subscriptionID, limit, offset)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -702,13 +703,14 @@ func (c *Client) CreateHookSubscription(payload CreateHookPayload) (*model.Hook,
 	var response model.Hook
 
 	url := "/api/v1/hooks/subscriptions/"
-	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	httpResponse, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Status(http.StatusCreated).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusCreated {
-		return nil, "", fmt.Errorf("unable to create hook subscription, status code: %v", httpResponse.StatusCode)
+		return nil, "", err
 	}
 
 	secret := httpResponse.Header.Get("X-Hook-Secret")
@@ -727,13 +729,14 @@ func (c *Client) ConfirmHookSubscription(subscriptionID, secret string) (*model.
 	}
 
 	url := fmt.Sprintf("/api/v1/hooks/subscriptions/%s/", subscriptionID)
-	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to confirm webhook subscription %s: %s", subscriptionID, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to confirm webhook subscription %s, status code: %v", subscriptionID, httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil
@@ -744,13 +747,14 @@ func (c *Client) UpdateHookSubscription(subscriptionID string, payload UpdateHoo
 	var response model.Hook
 
 	url := fmt.Sprintf("/api/v1/hooks/subscriptions/%s/", subscriptionID)
-	httpResponse, err := c.Execute(http.MethodPatch, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PatchRequest(url).
+		Body(payload).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to update hook subscription %s: %s", subscriptionID, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to update hook subscription %s, status code: %v", subscriptionID, httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil
@@ -759,13 +763,12 @@ func (c *Client) UpdateHookSubscription(subscriptionID string, payload UpdateHoo
 // DeleteHookSubscription deletes a hook subscription by ID.
 func (c *Client) DeleteHookSubscription(subscriptionID string) error {
 	url := fmt.Sprintf("/api/v1/hooks/subscriptions/%s/", subscriptionID)
-	httpResponse, err := c.Execute(http.MethodDelete, url, nil, nil)
+	_, err := c.ExecuteBuilder().
+		DeleteRequest(url).
+		Status(http.StatusNoContent).
+		Execute()
 	if err != nil {
-		return fmt.Errorf("unable to delete hook subscription %s: %s", subscriptionID, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unable to delete hook subscription %s, status code: %v", subscriptionID, httpResponse.StatusCode)
+		return err
 	}
 
 	return nil
@@ -775,13 +778,13 @@ func (c *Client) GetWorkspaces(limit, offset int) (*ListWorkspacesResponse, erro
 	var response ListWorkspacesResponse
 
 	url := fmt.Sprintf("/api/v1/workspaces/?limit=%v&offset=%v", limit, offset)
-	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		GetRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code was %v, so therefore unable to get workspaces", httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil
@@ -792,9 +795,9 @@ func (c *Client) GetWorkspaceBalance(workspaceID string) (*WorkspaceBalanceRespo
 	var response WorkspaceBalanceResponse
 
 	url := fmt.Sprintf("/api/v1/workspaces/%s/balance/", workspaceID)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -805,14 +808,14 @@ func (c *Client) CreateWorkspace(workspace model.Workspace) (*CreateWorkspacesRe
 	var response CreateWorkspacesResponse
 
 	url := "/api/v1/workspaces/"
-	httpResponse, err := c.Execute(http.MethodPost, url, workspace, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(workspace).
+		Status(http.StatusCreated).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to create workspace: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -823,14 +826,14 @@ func (c *Client) CreateInvitation(invitation model.CreateInvitation) (*CreateInv
 	var response CreateInvitationResponse
 
 	url := "/api/v1/invitations/"
-	httpResponse, err := c.Execute(http.MethodPost, url, invitation, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(invitation).
+		Status(http.StatusCreated).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to create invitation: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -841,9 +844,9 @@ func (c *Client) GetProjects(workspaceID string, limit, offset int) (*ListProjec
 	var response ListProjectsResponse
 
 	url := fmt.Sprintf("/api/v1/workspaces/%s/projects/?limit=%v&offset=%v", workspaceID, limit, offset)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -854,13 +857,13 @@ func (c *Client) GetProject(ID string) (*model.Project, error) {
 	var response model.Project
 
 	url := fmt.Sprintf("/api/v1/projects/%s/", ID)
-	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		GetRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code was %v, so therefore unable to get project: %v", httpResponse.StatusCode, ID)
+		return nil, err
 	}
 
 	return &response, nil
@@ -871,9 +874,13 @@ func (c *Client) CreateProject(workspaceID string, project model.Project) (*Crea
 	var response CreateProjectResponse
 
 	url := fmt.Sprintf("/api/v1/workspaces/%s/projects/", workspaceID)
-	_, err := c.Execute(http.MethodPost, url, project, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(project).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -884,9 +891,9 @@ func (c *Client) GetParticipantGroups(workspaceID string, limit, offset int) (*L
 	var response ListParticipantGroupsResponse
 
 	url := fmt.Sprintf("/api/v1/participant-groups/?workspace_id=%s&limit=%v&offset=%v", workspaceID, limit, offset)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -897,9 +904,9 @@ func (c *Client) GetParticipantGroup(groupID string) (*ViewParticipantGroupRespo
 	var response ViewParticipantGroupResponse
 
 	url := fmt.Sprintf("/api/v1/participant-groups/%s/participants/", groupID)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(url, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -910,9 +917,13 @@ func (c *Client) CreateParticipantGroup(group model.CreateParticipantGroup) (*Cr
 	var response CreateParticipantGroupResponse
 
 	url := "/api/v1/participant-groups/"
-	_, err := c.Execute(http.MethodPost, url, group, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(group).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -925,12 +936,14 @@ func (c *Client) RemoveParticipantGroupMembers(groupID string, participantIDs []
 	var response ViewParticipantGroupResponse
 
 	url := fmt.Sprintf("/api/v1/participant-groups/%s/participants/", groupID)
-	httpResponse, err := c.Execute(http.MethodDelete, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		DeleteRequest(url).
+		Body(payload).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to remove participants from group %s: %s", groupID, err)
-	}
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to remove participants from group %s, status code: %v", groupID, httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil
@@ -943,12 +956,14 @@ func (c *Client) AddParticipantGroupMembers(groupID string, participantIDs []str
 	var response ViewParticipantGroupResponse
 
 	url := fmt.Sprintf("/api/v1/participant-groups/%s/participants/", groupID)
-	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to add participants to group %s: %s", groupID, err)
-	}
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to add participants to group %s, status code: %v", groupID, httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil
@@ -963,14 +978,14 @@ func (c *Client) CreateTestParticipant(email string) (*CreateTestParticipantResp
 	}{Email: email}
 
 	url := "/api/v1/researchers/participants/"
-	httpResponse, err := c.Execute(http.MethodPost, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Status(http.StatusCreated).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to create test participant (status %d): %s", httpResponse.StatusCode, string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -1001,9 +1016,9 @@ func (c *Client) GetRewardRecommendations(workspaceID, currency string, screener
 	}
 
 	requestURL := "/api/v1/reward-recommendations/?" + query.Encode()
-	_, err := c.Execute(http.MethodGet, requestURL, nil, &response)
+	_, err := c.ExecuteBuilder().GetInto(requestURL, &response)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", requestURL, err)
+		return nil, err
 	}
 
 	return &response, nil

--- a/client/client.go
+++ b/client/client.go
@@ -276,14 +276,14 @@ func (c *Client) CreateStudy(study model.CreateStudy) (*model.Study, error) {
 	var response model.Study
 
 	url := "/api/v1/studies/"
-	httpResponse, err := c.Execute(http.MethodPost, url, study, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(study).
+		Status(http.StatusCreated).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to create study: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -306,14 +306,13 @@ func (c *Client) DuplicateStudy(ID string) (*model.Study, error) {
 	var response model.Study
 
 	url := fmt.Sprintf("/api/v1/studies/%s/clone/", ID)
-	httpResponse, err := c.Execute(http.MethodPost, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to duplicate study: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -356,9 +355,9 @@ func (c *Client) GetStudies(status, projectID string) (*ListStudiesResponse, err
 		}
 	}
 
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -369,14 +368,13 @@ func (c *Client) GetStudy(ID string) (*model.Study, error) {
 	var response model.Study
 
 	url := fmt.Sprintf("/api/v1/studies/%s", ID)
-	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		GetRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to get study: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -387,14 +385,13 @@ func (c *Client) GetStudySubmissionCounts(ID string) (*model.SubmissionCounts, e
 	var response model.SubmissionCounts
 
 	url := fmt.Sprintf("/api/v1/studies/%s/submissions/counts/", ID)
-	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		GetRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to get submission counts: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -405,9 +402,9 @@ func (c *Client) GetSubmissions(ID string, limit, offset int) (*ListSubmissionsR
 	var response ListSubmissionsResponse
 
 	url := fmt.Sprintf("/api/v1/studies/%s/submissions/?limit=%v&offset=%v", ID, limit, offset)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -422,9 +419,13 @@ func (c *Client) RequestSubmissionReturn(ID string, reasons []string) (*RequestS
 	}
 
 	url := fmt.Sprintf("/api/v1/submissions/%s/request-return/", ID)
-	_, err := c.Execute(http.MethodPost, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to request submission return: %s", err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -435,9 +436,13 @@ func (c *Client) TransitionSubmission(ID string, payload TransitionSubmissionPay
 	var response TransitionSubmissionResponse
 
 	url := fmt.Sprintf("/api/v1/submissions/%s/transition/", ID)
-	_, err := c.Execute(http.MethodPost, url, payload, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to transition submission: %s", err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -446,9 +451,9 @@ func (c *Client) TransitionSubmission(ID string, payload TransitionSubmissionPay
 // BulkApproveSubmissions will bulk approve multiple submissions.
 func (c *Client) BulkApproveSubmissions(payload BulkApproveSubmissionsPayload) error {
 	url := "/api/v1/submissions/bulk-approve/"
-	_, err := c.Execute(http.MethodPost, url, payload, nil)
+	_, err := c.ExecuteBuilder().PostRequest(url).Body(payload).Execute()
 	if err != nil {
-		return fmt.Errorf("unable to bulk approve submissions: %s", err)
+		return err
 	}
 
 	return nil
@@ -465,9 +470,13 @@ func (c *Client) TransitionStudy(ID, action string) (*TransitionStudyResponse, e
 	}
 
 	url := fmt.Sprintf("/api/v1/studies/%s/transition/", ID)
-	_, err := c.Execute(http.MethodPost, url, transition, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(transition).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to transition study to %s: %v", action, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -478,9 +487,9 @@ func (c *Client) GetCampaigns(workspaceID string, limit, offset int) (*ListCampa
 	var response ListCampaignsResponse
 
 	url := fmt.Sprintf("/api/v1/campaigns/?workspace_id=%s&limit=%v&offset=%v", workspaceID, limit, offset)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -491,9 +500,9 @@ func (c *Client) GetCollections(workspaceID string, limit, offset int) (*ListCol
 	var response ListCollectionsResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections?workspace_id=%s&limit=%v&offset=%v", workspaceID, limit, offset)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -504,14 +513,13 @@ func (c *Client) GetCollection(ID string) (*model.Collection, error) {
 	var response model.Collection
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections/%s", ID)
-	httpResponse, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		GetRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("unable to get collection: %v", string(body))
+		return nil, err
 	}
 
 	return &response, nil
@@ -524,9 +532,9 @@ func (c *Client) InitiateCollectionExport(collectionID string) (*CollectionExpor
 	var response CollectionExportResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections/%s/export", collectionID)
-	_, err := c.Execute(http.MethodPost, url, nil, &response)
+	_, err := c.ExecuteBuilder().PostRequest(url).Decode(&response).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -538,9 +546,9 @@ func (c *Client) GetCollectionExportStatus(collectionID, exportID string) (*Coll
 	var response CollectionExportResponse
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections/%s/export/%s", collectionID, exportID)
-	_, err := c.Execute(http.MethodGet, url, nil, &response)
+	_, err := c.ExecuteBuilder().GetRequest(url).Decode(&response).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return nil, err
 	}
 
 	return &response, nil
@@ -551,13 +559,14 @@ func (c *Client) UpdateStudy(ID string, study any) (*model.Study, error) {
 	var response model.Study
 
 	url := fmt.Sprintf("/api/v1/studies/%s/", ID)
-	httpResponse, err := c.Execute(http.MethodPatch, url, study, &response)
+	_, err := c.ExecuteBuilder().
+		PatchRequest(url).
+		Body(study).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
 		return nil, fmt.Errorf("unable to update study: %v", err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, errors.New(`unable to update study`)
 	}
 
 	return &response, nil
@@ -566,7 +575,7 @@ func (c *Client) UpdateStudy(ID string, study any) (*model.Study, error) {
 // GetStudyCredentialsUsageReportCSV will return the credentials usage report for a study as CSV.
 func (c *Client) GetStudyCredentialsUsageReportCSV(ID string) (string, error) {
 	endpointURL := fmt.Sprintf("/api/v1/studies/%s/credentials/report/", ID)
-	httpResponse, err := c.Execute(http.MethodGet, endpointURL, nil, nil)
+	httpResponse, err := c.ExecuteBuilder().GetRequest(endpointURL).Execute()
 	if err != nil {
 		return "", err
 	}
@@ -582,9 +591,9 @@ func (c *Client) GetStudyCredentialsUsageReportCSV(ID string) (string, error) {
 // ExportDemographics triggers a demographic data export for all submissions in a study.
 func (c *Client) ExportDemographics(ID string) (string, error) {
 	url := fmt.Sprintf("/api/v1/studies/%s/demographic-export/", ID)
-	httpResponse, err := c.Execute(http.MethodPost, url, nil, nil)
+	httpResponse, err := c.ExecuteBuilder().PostRequest(url).Execute()
 	if err != nil {
-		return "", fmt.Errorf("unable to fulfil request %s: %s", url, err)
+		return "", err
 	}
 
 	responseBody, err := io.ReadAll(httpResponse.Body)
@@ -600,13 +609,13 @@ func (c *Client) TestStudy(ID string) (*TestStudyResponse, error) {
 	var response TestStudyResponse
 
 	url := fmt.Sprintf("/api/v1/studies/%s/test-study/", ID)
-	httpResponse, err := c.Execute(http.MethodPost, url, nil, &response)
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to fulfil request %s: %s", url, err)
-	}
-
-	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: expected 200, got %d", httpResponse.StatusCode)
+		return nil, err
 	}
 
 	return &response, nil

--- a/client/client.go
+++ b/client/client.go
@@ -368,11 +368,7 @@ func (c *Client) GetStudy(ID string) (*model.Study, error) {
 	var response model.Study
 
 	url := fmt.Sprintf("/api/v1/studies/%s", ID)
-	_, err := c.ExecuteBuilder().
-		GetRequest(url).
-		Status(http.StatusOK).
-		Decode(&response).
-		Execute()
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -385,11 +381,7 @@ func (c *Client) GetStudySubmissionCounts(ID string) (*model.SubmissionCounts, e
 	var response model.SubmissionCounts
 
 	url := fmt.Sprintf("/api/v1/studies/%s/submissions/counts/", ID)
-	_, err := c.ExecuteBuilder().
-		GetRequest(url).
-		Status(http.StatusOK).
-		Decode(&response).
-		Execute()
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -513,11 +505,7 @@ func (c *Client) GetCollection(ID string) (*model.Collection, error) {
 	var response model.Collection
 
 	url := fmt.Sprintf("/api/v1/data-collection/collections/%s", ID)
-	_, err := c.ExecuteBuilder().
-		GetRequest(url).
-		Status(http.StatusOK).
-		Decode(&response).
-		Execute()
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -778,11 +766,7 @@ func (c *Client) GetWorkspaces(limit, offset int) (*ListWorkspacesResponse, erro
 	var response ListWorkspacesResponse
 
 	url := fmt.Sprintf("/api/v1/workspaces/?limit=%v&offset=%v", limit, offset)
-	_, err := c.ExecuteBuilder().
-		GetRequest(url).
-		Status(http.StatusOK).
-		Decode(&response).
-		Execute()
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -857,11 +841,7 @@ func (c *Client) GetProject(ID string) (*model.Project, error) {
 	var response model.Project
 
 	url := fmt.Sprintf("/api/v1/projects/%s/", ID)
-	_, err := c.ExecuteBuilder().
-		GetRequest(url).
-		Status(http.StatusOK).
-		Decode(&response).
-		Execute()
+	_, err := c.ExecuteBuilder().Get(url, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -566,7 +566,7 @@ func (c *Client) UpdateStudy(ID string, study any) (*model.Study, error) {
 		Decode(&response).
 		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("unable to update study: %v", err)
+		return nil, err
 	}
 
 	return &response, nil

--- a/client/execute_builder.go
+++ b/client/execute_builder.go
@@ -27,6 +27,18 @@ func (b *ExecuteBuilder) GetRequest(url string) *ExecuteBuilder {
 	return b.newRequest(http.MethodGet, url)
 }
 
+func (b *ExecuteBuilder) PostRequest(url string) *ExecuteBuilder {
+	return b.newRequest(http.MethodPost, url)
+}
+
+func (b *ExecuteBuilder) PatchRequest(url string) *ExecuteBuilder {
+	return b.newRequest(http.MethodPatch, url)
+}
+
+func (b *ExecuteBuilder) DeleteRequest(url string) *ExecuteBuilder {
+	return b.newRequest(http.MethodDelete, url)
+}
+
 // newRequest clears any state carried over from a previous request, so a
 // builder that is held and reused cannot send an earlier request's body or
 // accept an earlier request's statuses.
@@ -59,6 +71,12 @@ func (b *ExecuteBuilder) Execute() (*http.Response, error) {
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to fulfil request %s: %s", b.url, err)
+	}
+
+	// Status was never called: Client.Execute already treated anything below
+	// 400 as a success, so there's nothing further to assert here.
+	if len(b.expectedStatuses) == 0 {
+		return httpResponse, nil
 	}
 
 	// Check if the status code is one of the accepted ones

--- a/client/execute_builder.go
+++ b/client/execute_builder.go
@@ -23,6 +23,14 @@ func (b *ExecuteBuilder) Get(url string, response any) (*http.Response, error) {
 	return b.GetRequest(url).Status(http.StatusOK).Decode(response).Execute()
 }
 
+// GetInto sends a GET request and decodes the response, accepting any status
+// Client.Execute already treated as a success (see Execute) rather than
+// asserting a specific one — for endpoints where the caller never checked
+// the status code beyond that.
+func (b *ExecuteBuilder) GetInto(url string, response any) (*http.Response, error) {
+	return b.GetRequest(url).Decode(response).Execute()
+}
+
 func (b *ExecuteBuilder) GetRequest(url string) *ExecuteBuilder {
 	return b.newRequest(http.MethodGet, url)
 }

--- a/client/execute_builder_test.go
+++ b/client/execute_builder_test.go
@@ -38,6 +38,33 @@ func TestExecuteBuilderGet(t *testing.T) {
 	require.Equal(t, "test", resp.Name)
 }
 
+// GetInto accepts any status Client.Execute already treated as a success,
+// unlike Get which asserts 200 — this covers callers that never checked the
+// status code beyond that.
+func TestExecuteBuilderGetIntoAcceptsAnySuccessStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(testResponse{ID: "123", Name: "test"}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	var resp testResponse
+	httpResponse, err := c.ExecuteBuilder().GetInto("/some-path", &resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, httpResponse.StatusCode)
+	require.Equal(t, "123", resp.ID)
+}
+
 func TestExecuteBuilderGetReturnsErrorOnHTTPFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/client/execute_builder_test.go
+++ b/client/execute_builder_test.go
@@ -112,3 +112,114 @@ func TestExecuteBuilderExecuteAcceptsAConfiguredStatus(t *testing.T) {
 	require.Equal(t, http.StatusCreated, httpResponse.StatusCode)
 	require.Equal(t, "123", resp.ID)
 }
+
+// Without a Status call, the builder accepts whatever Client.Execute treated
+// as a success (i.e. anything below 400) rather than erroring on every
+// request — this covers callers that never asserted a specific status code.
+func TestExecuteBuilderExecuteWithoutStatusAcceptsAnySuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(testResponse{ID: "123", Name: "test"}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	var resp testResponse
+	httpResponse, err := c.ExecuteBuilder().
+		GetRequest("/some-path").
+		Decode(&resp).
+		Execute()
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, httpResponse.StatusCode)
+	require.Equal(t, "123", resp.ID)
+}
+
+func TestExecuteBuilderPostRequestSendsBodyAndMethod(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		var got testResponse
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(got); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	var resp testResponse
+	httpResponse, err := c.ExecuteBuilder().
+		PostRequest("/some-path").
+		Body(testResponse{ID: "123", Name: "test"}).
+		Status(http.StatusCreated).
+		Decode(&resp).
+		Execute()
+
+	require.NoError(t, err)
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, http.StatusCreated, httpResponse.StatusCode)
+	require.Equal(t, "123", resp.ID)
+}
+
+func TestExecuteBuilderPatchRequestUsesPatchMethod(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	_, err := c.ExecuteBuilder().
+		PatchRequest("/some-path").
+		Body(testResponse{ID: "123"}).
+		Status(http.StatusOK).
+		Execute()
+
+	require.NoError(t, err)
+	require.Equal(t, http.MethodPatch, gotMethod)
+}
+
+func TestExecuteBuilderDeleteRequestUsesDeleteMethod(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := Client{
+		Client:  http.DefaultClient,
+		BaseURL: srv.URL,
+		Token:   "fake-token",
+	}
+
+	_, err := c.ExecuteBuilder().
+		DeleteRequest("/some-path").
+		Status(http.StatusNoContent).
+		Execute()
+
+	require.NoError(t, err)
+	require.Equal(t, http.MethodDelete, gotMethod)
+}

--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -299,8 +299,6 @@ var operations = []operation{
 	{operationID: "export-demographic-data", skip: "SPECMISMATCH: spec requires a request body, client sends none"},
 	{operationID: "get-demographic-export-history", skip: "OUTOFSCOPE: no CLI command for demographic export history"},
 	{operationID: "duplicate-study", skip: "SPECMISMATCH: spec requires a request body, client sends none"},
-	{operationID: "get-study-predicted-recruitment-time", skip: "OUTOFSCOPE: no CLI command for predicted recruitment time"},
-	{operationID: "post-study-predicted-recruitment-time", skip: "OUTOFSCOPE: no CLI command for posting predicted recruitment time"},
 	{operationID: "calculate-study-cost", skip: "OUTOFSCOPE: no CLI command for calculating study cost"},
 
 	// Credentials


### PR DESCRIPTION
## Summary

ExecuteBuilder migration (DCT-266): extends the builder to all HTTP verbs and migrates 41 study/submission/campaign/collection/hook/workspace/project/participant-group methods onto it, removing their repeated status-check/error-wrap boilerplate. Also fixes an unrelated pre-existing failure (DCT-261) that was blocking `make test` on `main`.

## ExecuteBuilder changes

- Added `PostRequest`/`PatchRequest`/`DeleteRequest` (was GET-only), and `GetInto` — GET+decode without asserting a status, extracted after the same chain repeated several times
- Fixed a bug where omitting `Status(...)` always errored with "unexpected status code" instead of accepting whatever `Client.Execute` already treated as a success — this is what makes migrating status-agnostic methods possible without changing behaviour

## Migrated (44 of 90 methods)

Study/submission/campaign/collection group, plus hooks, workspaces, projects, invitations, and participant groups. Full list in the commit messages. No behavioural changes — verified via `contract_test`'s spec-matching test. Remaining ~46 methods (filters, surveys, messages, bonus payments, AI Task Builder, credential pools) will follow in a second PR.

## Also included: DCT-261 fix

`contract_test` downloads the live Prolific OpenAPI spec every run and diffs it against a hardcoded table. Two operations removed from the real API were still listed, failing `make test` on `main` unconditionally. Removed the stale entries.

## Testing

New `ExecuteBuilder` tests, full suite (`make test`), and `make lint` all pass.