### PR TITLE
test(DCT-261): close stale contract-test gaps for API schema drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+### Core
+
+- Tighten contract testing against the Prolific API spec
+
 ## 1.2.1
 
 ### Core

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -215,6 +217,46 @@ func TestCreateAITaskBuilderBatch(t *testing.T) {
 				t.Fatalf("expected error to contain %q, got %q", tt.wantErr, err.Error())
 			}
 		})
+	}
+}
+
+// TestGetParticipantGroupsSendsWorkspaceIDQueryParam guards the request shape
+// directly, since contract_test skips this operation (HARNESSGAP: kin-openapi
+// can't decode its oneOf-of-objects query param).
+func TestGetParticipantGroupsSendsWorkspaceIDQueryParam(t *testing.T) {
+	var gotQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(ListParticipantGroupsResponse{}); err != nil {
+			t.Logf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	c := Client{
+		Client:  server.Client(),
+		BaseURL: server.URL,
+		Token:   "test-token",
+	}
+
+	_, err := c.GetParticipantGroups("ws-id", 10, 0)
+	if err != nil {
+		t.Fatalf("GetParticipantGroups returned error: %v", err)
+	}
+
+	if got := gotQuery.Get("workspace_id"); got != "ws-id" {
+		t.Errorf("workspace_id = %q, want %q", got, "ws-id")
+	}
+	if got := gotQuery.Get("limit"); got != "10" {
+		t.Errorf("limit = %q, want %q", got, "10")
+	}
+	if got := gotQuery.Get("offset"); got != "0" {
+		t.Errorf("offset = %q, want %q", got, "0")
+	}
+	if gotQuery.Has("project_id") {
+		t.Errorf("project_id should not be sent, got %q", gotQuery.Get("project_id"))
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -224,8 +224,11 @@ func TestCreateAITaskBuilderBatch(t *testing.T) {
 // directly, since contract_test skips this operation (HARNESSGAP: kin-openapi
 // can't decode its oneOf-of-objects query param).
 func TestGetParticipantGroupsSendsWorkspaceIDQueryParam(t *testing.T) {
+	var gotMethod, gotPath string
 	var gotQuery url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
 		gotQuery = r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -246,6 +249,12 @@ func TestGetParticipantGroupsSendsWorkspaceIDQueryParam(t *testing.T) {
 		t.Fatalf("GetParticipantGroups returned error: %v", err)
 	}
 
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want %q", gotMethod, http.MethodGet)
+	}
+	if want := "/api/v1/participant-groups/"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
 	if got := gotQuery.Get("workspace_id"); got != "ws-id" {
 		t.Errorf("workspace_id = %q, want %q", got, "ws-id")
 	}

--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -9,6 +9,7 @@
 // Skip tags used in the operations table:
 //   - OUTOFSCOPE   — no CLI command exists or is planned for this endpoint
 //   - SPECMISMATCH — client request diverges from the spec; needs a fix
+//   - HARNESSGAP   — client behaviour is correct; kin-openapi can't validate this shape
 
 package contracttest
 
@@ -296,9 +297,9 @@ var operations = []operation{
 		c.GetStudyCredentialsUsageReportCSV("study-id")
 	}},
 	{operationID: "export-study", skip: "OUTOFSCOPE: no CLI command for exporting a study as a whole"},
-	{operationID: "export-demographic-data", skip: "SPECMISMATCH: spec requires a request body, client sends none"},
+	{operationID: "export-demographic-data", call: func(c *client.Client) { c.ExportDemographics("study-id") }},
 	{operationID: "get-demographic-export-history", skip: "OUTOFSCOPE: no CLI command for demographic export history"},
-	{operationID: "duplicate-study", skip: "SPECMISMATCH: spec requires a request body, client sends none"},
+	{operationID: "duplicate-study", call: func(c *client.Client) { c.DuplicateStudy("study-id") }},
 	{operationID: "calculate-study-cost", skip: "OUTOFSCOPE: no CLI command for calculating study cost"},
 
 	// Credentials
@@ -350,7 +351,7 @@ var operations = []operation{
 	}},
 
 	// Participant Groups
-	{operationID: "get-participant-groups", skip: "SPECMISMATCH: spec uses a filter deepObject query param, client sends it flat"},
+	{operationID: "get-participant-groups", skip: "HARNESSGAP: kin-openapi v0.146.0 mis-decodes a top-level oneOf-of-objects query param under the default form/explode=true style — it always resolves to the last oneOf branch (project_id), discarding an earlier correct match (workspace_id), so oneOf validation fails regardless of how the client sends it. Client's flat workspace_id=X is correct per spec defaults and per the real API (see commit 8c7aae6 / DCP-2272)."},
 	{operationID: "create-participant-group", call: func(c *client.Client) {
 		c.CreateParticipantGroup(model.CreateParticipantGroup{Name: "t", WorkspaceID: "ws-id"})
 	}},


### PR DESCRIPTION
## Summary

Two of `contract_test.go`'s three `SPECMISMATCH` skips were stale — the client was already spec-compliant. Closed those gaps and fixed the third one's diagnosis.

## What changed

- **`export-demographic-data`** / **`duplicate-study`**: neither's `requestBody` is actually required by the spec, and kin-openapi passes an empty, non-required body. The skips were wrong — now real, passing assertions.
- **`get-participant-groups`**: also mislabeled ("deepObject" isn't even declared). The client's flat `workspace_id=X` is correct — the real issue is a kin-openapi bug misdecoding a top-level `oneOf`-of-objects query param. Relabeled under a new `HARNESSGAP` tag so nobody "fixes" already-correct code later.
- Added a dedicated `client_test.go` test asserting `GetParticipantGroups`'s method/path/query directly, since it's now the only thing guarding that request shape.

No `client.go` changes — this was a test-harness fix, not a CLI fix.

## Testing

`make test` and `make lint` pass.