### PR TITLE
feat(DCT-262): detect API schema drift on a schedule, file an issue

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -1,0 +1,83 @@
+name: Schema Drift Check
+
+# Runs contract_test against the LIVE Prolific OpenAPI spec independently of
+# any push/PR activity, so drift is caught even when nothing else in the repo
+# changes. On failure, files a scoped GitHub issue with the exact failing
+# test output and a task checklist — see AGENTS.md for how this fits into
+# the wider schema-drift automation (DCT-262).
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version: 1.26.5
+
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Get dependencies
+        run: make install
+
+      - name: Run contract tests against the live API spec
+        id: contract_test
+        run: |
+          # No -v: verbose output buries the ~2-line failure signal under
+          # hundreds of passing-subtest lines (verified: 11.5KB vs 355 bytes
+          # for the same failure).
+          go test ./contract_test/... > contract-test-output.txt 2>&1 || true
+          if grep -q "^FAIL" contract-test-output.txt; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an already-open schema-drift issue
+        if: steps.contract_test.outputs.drift == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh issue list --repo "${{ github.repository }}" --label schema-drift --state open --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: File a schema-drift issue
+        if: steps.contract_test.outputs.drift == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "Contract tests (\`go test ./contract_test/...\`) failed against the live Prolific OpenAPI spec — this usually means the API has changed in a way the CLI doesn't yet handle."
+            echo ""
+            echo "## Failing test output"
+            echo ""
+            echo '```'
+            cat contract-test-output.txt
+            echo '```'
+            echo ""
+            echo "## What likely needs to change"
+            echo ""
+            echo "Follow AGENTS.md's \"Adding a New API Method\" checklist:"
+            echo ""
+            echo "- [ ] Update the \`API\` interface in \`client/client.go\` and implement on the \`Client\` struct"
+            echo "- [ ] Add/update request/response structs in \`client/payloads.go\`/\`client/responses.go\`"
+            echo "- [ ] Run \`make test-gen-mock\` to regenerate \`mock_client/mock_client.go\`"
+            echo "- [ ] Update the relevant entry (or entries) in \`contract_test/contract_test.go\`'s \`operations\` table"
+            echo "- [ ] Run \`make readme-coverage\` to refresh the API coverage table in \`README.md\`"
+            echo "- [ ] \`make test\` and \`make lint\` pass"
+          } > issue-body.md
+
+          gh issue create --repo "${{ github.repository }}" \
+            --title "API schema drift detected ($(date -u +%Y-%m-%d))" \
+            --label schema-drift \
+            --body-file issue-body.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,16 @@ This uses `git-cliff` (must be installed separately: `brew install git-cliff`) p
 
 To include hand-written notes in the next release, add them under `## next` in `CHANGELOG.md` before running `make changelog` — they will be merged in automatically.
 
+## Schema Drift Detection
+
+`.github/workflows/schema-drift-check.yml` runs `contract_test` (see `contract_test/contract_test.go`) daily on a schedule, independent of any push/PR activity, so drift is caught even when nothing else in the repo changes. `contract_test` already downloads the *live* Prolific OpenAPI spec on every run — this workflow just gives it a reason to run on its own.
+
+On failure, it files a GitHub issue labeled `schema-drift` with the exact failing test output and a checklist mirroring "Adding a New API Method" above. It skips filing if an open `schema-drift` issue already exists, so a persistent unresolved drift doesn't spam a new issue every day.
+
+Trigger it manually to test: `gh workflow run schema-drift-check.yml`.
+
+**Known gap:** the filed issue isn't currently auto-assigned to anyone (including GitHub Copilot coding agent) — as of this writing, Copilot coding agent has no access to this repo (`"Bot does not have access to the repository"` when tested via the GraphQL `replaceActorsForAssignable` mutation), which would need an org admin to re-enable before that part of DCT-262's original automation goal can be completed. Until then, filed issues need a human to notice and either fix directly or manually assign.
+
 ## Boundaries
 
 **Always do:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ On failure, it files a GitHub issue labeled `schema-drift` with the exact failin
 
 Trigger it manually to test: `gh workflow run schema-drift-check.yml`.
 
-**Known gap:** the filed issue isn't currently auto-assigned to anyone (including GitHub Copilot coding agent) — as of this writing, Copilot coding agent has no access to this repo (`"Bot does not have access to the repository"` when tested via the GraphQL `replaceActorsForAssignable` mutation), which would need an org admin to re-enable before that part of DCT-262's original automation goal can be completed. Until then, filed issues need a human to notice and either fix directly or manually assign.
+**No auto-assignment:** filed issues aren't auto-assigned to anyone. Auto-assigning to GitHub Copilot coding agent was investigated but requires org-level access this repo doesn't currently have (`"Bot does not have access to the repository"`, confirmed via the GraphQL `replaceActorsForAssignable` mutation) — and separately, running any unattended AI agent against a public repo's issues/PRs raises its own governance questions (prompt-injection surface from public issue content, unattended write access) that are unresolved regardless of which agent. Until that's settled, a human picks up filed issues; a `schema-drift-fix` skill for speeding that up (human-run, not unattended) is planned (DCT-262).
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

Prototype for DCT-262: automatically detect when the live Prolific API spec drifts from what the CLI expects, and surface it as an issue — no push/PR activity required to trigger detection.

## What changed

`.github/workflows/schema-drift-check.yml` runs `contract_test` daily on a cron schedule (+ `workflow_dispatch` for manual testing). `contract_test` already downloads the live spec and fails precisely on drift — this just gives it a reason to run independently. On failure:
- Files a `schema-drift`-labeled issue with the exact failing test output (using plain `go test` output, not `-v` — verified `-v` is 33x noisier for the same failure: 11.5KB vs 355 bytes, almost entirely passing-subtest noise)
- Includes a checklist mirroring `AGENTS.md`'s "Adding a New API Method" steps
- Skips filing if a `schema-drift` issue is already open, so persistent unresolved drift doesn't spam daily

## What's not done yet: auto-assignment

The original ticket scope wanted an AI agent to pick up the filed issue and open a fix PR automatically. Investigated GitHub Copilot coding agent first — confirmed via the GraphQL `replaceActorsForAssignable` mutation that it has no access to this repo ("Bot does not have access to the repository"), which would need org-admin approval to fix. Raised that with Cloud Platform/SecOps: no policy blocker was found in this PR itself, but there's no existing policy for AI coding agent access on a public repo either, and it's been parked as important-not-urgent pending bandwidth.

Considered self-hosting the same idea via a GitHub Action (e.g. Claude Code) instead — but that doesn't actually avoid the underlying question, it just skips the org-approval checkpoint entirely: an unattended AI agent reading public issue content and opening PRs on a public repo carries the same governance concerns (prompt-injection surface, unattended write access) regardless of which vendor. Not pursuing that.

Shipping the detection + issue-filing half now since it's fully working and valuable on its own; documented this in `AGENTS.md`. Follow-up direction is a `schema-drift-fix` skill a human runs by hand when picking up a filed issue — a time-save without an unattended agent in the loop.

## Testing

Verified the drift-detection logic locally against both a clean state (correctly reports no drift) and a deliberately corrupted `contract_test.go` entry (correctly detects failure and produces a clean, actionable issue body). `actionlint` passes on the workflow YAML. `make test`/`make lint` pass.
