### PR TITLE
feat(DCT-263): auto-open a release PR when unreleased commits pile up

### DIFF
--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -131,12 +131,15 @@ jobs:
           git commit -m "chore(release): update CHANGELOG.md for v${VERSION}"
           git push --force-with-lease origin "$BRANCH"
 
-          # A prior run may have pushed this branch and opened a PR that was
-          # later closed without merging (e.g. rejected content) without the
-          # branch being deleted — matches create-release.yml's
-          # update-homebrew-tap job, which guards the same way.
-          if gh pr view --repo "${{ github.repository }}" "$BRANCH" >/dev/null 2>&1; then
-            echo "PR for \`$BRANCH\` already exists, skipping creation."
+          # Only skip if a PR for this branch is still OPEN. A closed
+          # (unmerged) PR means a reviewer deferred the release — not that
+          # it's rejected forever — so a new PR should be re-proposed next
+          # run as long as unreleased work remains. Checking state, not just
+          # existence, is what makes closing a PR a snooze rather than a
+          # permanent mute.
+          STATE=$(gh pr view --repo "${{ github.repository }}" "$BRANCH" --json state --jq .state 2>/dev/null || echo "NONE")
+          if [ "$STATE" = "OPEN" ]; then
+            echo "PR for \`$BRANCH\` is already open, skipping creation."
             exit 0
           fi
 
@@ -146,6 +149,8 @@ jobs:
             echo "Version was auto-computed as a **PATCH** bump (\`${LATEST_TAG}\` -> \`v${VERSION}\`). If this batch of changes includes a breaking change (a removed flag, a changed output format — see the version-bump table in DEVELOPMENT.md), edit the \`## ${VERSION}\` heading in \`CHANGELOG.md\` to the next **MINOR** version before merging."
             echo ""
             echo "Merging this PR (with the \`release\` label, already applied) will trigger \`create-release.yml\` as usual — nothing is released until then."
+            echo ""
+            echo "Not the right time (other work still landing, want to batch more in)? Just close this without merging — it won't reopen itself, but if unreleased commits still remain, the next scheduled run will propose a fresh PR."
           } > pr-body.md
 
           gh pr create \

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -153,10 +153,14 @@ jobs:
             echo "Not the right time (other work still landing, want to batch more in)? Just close this without merging — it won't reopen itself, but if unreleased commits still remain, the next scheduled run will propose a fresh PR."
           } > pr-body.md
 
+          # dct-ready-for-review triggers a Slack notification so DCT (who
+          # own CLI releases for now) gets nudged. Swap or remove once
+          # release ownership moves to an OSS maintainer group.
           gh pr create \
             --repo "${{ github.repository }}" \
             --title "chore(release): v${VERSION}" \
             --label release \
+            --label dct-ready-for-review \
             --body-file pr-body.md \
             --head "$BRANCH" \
             --base main

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -42,17 +42,33 @@ jobs:
 
       - name: Get latest tag
         id: tag
-        run: echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          # Validated strictly before use anywhere else, including as a
+          # templated expression interpolated into a third-party action's
+          # `with:` input below (which that action then splices into its
+          # own internal shell command) — the standard GH Actions script-
+          # injection pattern. Creating a tag needs write access already,
+          # so this is a defense-in-depth boundary against a compromised or
+          # malicious trusted account, not a fix for an open/anyone-can-hit
+          # vulnerability.
+          if ! [[ "$LATEST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::latest tag '${LATEST_TAG}' doesn't match the expected vX.Y.Z format"
+            exit 1
+          fi
+          echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
 
       # Installs git-cliff and fails the job if it errors (exit code is
       # propagated by the action itself). Using the action instead of a
       # hand-rolled curl install also means Dependabot's already-configured
       # github-actions ecosystem tracks git-cliff's pinned version here —
       # a plain version string in a shell script, as this used to be, is
-      # invisible to it.
+      # invisible to it. SHA-pinned (Dependabot still tracks and bumps this,
+      # updating both the SHA and the version comment).
       - name: Generate unreleased changelog notes
         id: cliff
-        uses: orhun/git-cliff-action@v4.8.0
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --unreleased --strip header ${{ steps.tag.outputs.latest_tag }}..HEAD

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -40,48 +40,37 @@ jobs:
         with:
           go-version: 1.26.5
 
-      - name: Install git-cliff
-        run: |
-          set -euo pipefail
-          ASSET="git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz"
-          BASE_URL="https://github.com/orhun/git-cliff/releases/download/v2.13.1"
+      - name: Get latest tag
+        id: tag
+        run: echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
 
-          curl -sSL -o "$ASSET" "${BASE_URL}/${ASSET}"
-          curl -sSL -o "${ASSET}.sha512" "${BASE_URL}/${ASSET}.sha512"
-          sha512sum -c "${ASSET}.sha512"
+      # Installs git-cliff and fails the job if it errors (exit code is
+      # propagated by the action itself). Using the action instead of a
+      # hand-rolled curl install also means Dependabot's already-configured
+      # github-actions ecosystem tracks git-cliff's pinned version here —
+      # a plain version string in a shell script, as this used to be, is
+      # invisible to it.
+      - name: Generate unreleased changelog notes
+        id: cliff
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          config: cliff.toml
+          args: --unreleased --strip header ${{ steps.tag.outputs.latest_tag }}..HEAD
 
-          tar -xzf "$ASSET"
-          sudo mv git-cliff-2.13.1/git-cliff /usr/local/bin/git-cliff
-          git-cliff --version
+      - name: Make git-cliff available on PATH for later steps
+        run: echo "$RUNNER_TEMP/git-cliff/bin" >> "$GITHUB_PATH"
 
       - name: Check for unreleased user-facing commits
         id: detect
-        run: |
-          set -euo pipefail
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-
+        env:
           # Reuses cliff.toml's own commit-type filtering (the same rules
-          # `make changelog` uses) rather than re-deriving the feat/fix/docs/
-          # perf/refactor/revert/test inclusion list a second time here.
-          # Exit code is checked explicitly (rather than swallowing stderr
-          # and guessing from stdout content) so a git-cliff failure fails
-          # the job loudly instead of being silently misread as "nothing to
-          # release" or a false-positive "something to release". stdout and
-          # stderr are kept separate: git-cliff's INFO/WARN diagnostics go
-          # to stderr on every run (even successful ones), so merging them
-          # into the content check would make it permanently non-empty.
-          set +e
-          RAW=$(git-cliff "${LATEST_TAG}"..HEAD --unreleased --strip header --config cliff.toml 2>git-cliff-stderr.log)
-          STATUS=$?
-          set -e
-          if [ "$STATUS" -ne 0 ]; then
-            echo "::error::git-cliff failed with exit code ${STATUS}:"
-            cat git-cliff-stderr.log
-            exit 1
-          fi
-
-          NOTES=$(echo "$RAW" | tr -d '[:space:]')
+          # `make changelog` uses) instead of re-deriving the inclusion
+          # list here. Read from the action's `content` output, which is
+          # sourced from git-cliff's output file rather than stdout, so
+          # there's no diagnostic-log noise to filter out.
+          CONTENT: ${{ steps.cliff.outputs.content }}
+        run: |
+          NOTES=$(echo "$CONTENT" | tr -d '[:space:]')
           if [ -z "$NOTES" ]; then
             echo "has_unreleased=false" >> "$GITHUB_OUTPUT"
           else
@@ -101,7 +90,7 @@ jobs:
         if: steps.detect.outputs.has_unreleased == 'true' && steps.existing.outputs.count == '0'
         id: version
         env:
-          LATEST_TAG: ${{ steps.detect.outputs.latest_tag }}
+          LATEST_TAG: ${{ steps.tag.outputs.latest_tag }}
         run: |
           CURRENT="${LATEST_TAG#v}"
           NEXT=$(go run ./scripts/changelog next-version --bump patch "$CURRENT")
@@ -112,7 +101,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPO_CONTENTS_WRITE }}
           VERSION: ${{ steps.version.outputs.next }}
-          LATEST_TAG: ${{ steps.detect.outputs.latest_tag }}
+          LATEST_TAG: ${{ steps.tag.outputs.latest_tag }}
         run: |
           set -euo pipefail
           BRANCH="release/v${VERSION}"

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -1,0 +1,115 @@
+name: Release Cadence Check
+
+# Detects unreleased user-facing commits on main and opens a release PR
+# automatically — it never merges, tags, or releases anything itself.
+# Actual release creation still only happens via create-release.yml, which
+# only fires from a human-approved merge of a PR carrying the `release`
+# label (branch protection: 1 approval + passing Build required). This is a
+# convenience for step 1-2 of the "Release Process" in README.md, not a
+# bypass of step 3.
+#
+# Runs on schedule/workflow_dispatch only (never pull_request/
+# pull_request_target) — this repo is public, and those triggers can run in
+# fork-PR context with secrets exposed; schedule/workflow_dispatch always
+# run against the base repo with its own permissions.
+on:
+  schedule:
+    - cron: "9 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-release-cadence:
+    runs-on: ubuntu-latest
+    environment: main
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version: 1.26.5
+
+      - name: Install git-cliff
+        run: |
+          curl -sSL -o git-cliff.tar.gz \
+            https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf git-cliff.tar.gz
+          sudo mv git-cliff-2.13.1/git-cliff /usr/local/bin/git-cliff
+          git-cliff --version
+
+      - name: Check for unreleased user-facing commits
+        id: detect
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Reuses cliff.toml's own commit-type filtering (the same rules
+          # `make changelog` uses) rather than re-deriving the feat/fix/docs/
+          # perf/refactor/revert/test inclusion list a second time here.
+          NOTES=$(git-cliff "${LATEST_TAG}"..HEAD --unreleased --strip header --config cliff.toml 2>/dev/null | tr -d '[:space:]')
+          if [ -z "$NOTES" ]; then
+            echo "has_unreleased=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_unreleased=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an already-open release PR
+        if: steps.detect.outputs.has_unreleased == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh pr list --repo "${{ github.repository }}" --label release --state open --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        if: steps.detect.outputs.has_unreleased == 'true' && steps.existing.outputs.count == '0'
+        id: version
+        env:
+          LATEST_TAG: ${{ steps.detect.outputs.latest_tag }}
+        run: |
+          CURRENT="${LATEST_TAG#v}"
+          NEXT=$(go run ./scripts/changelog next-version --bump patch "$CURRENT")
+          echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Open a release PR
+        if: steps.detect.outputs.has_unreleased == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.REPO_CONTENTS_WRITE }}
+          VERSION: ${{ steps.version.outputs.next }}
+          LATEST_TAG: ${{ steps.detect.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/v${VERSION}"
+
+          make changelog VERSION="${VERSION}"
+
+          git config user.name "Prolific Automation"
+          git config user.email "prolific-automation@prolific.com"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "chore(release): update CHANGELOG.md for v${VERSION}"
+          git push --force-with-lease origin "$BRANCH"
+
+          {
+            echo "Automated release PR — detected unreleased user-facing commits since \`${LATEST_TAG}\`."
+            echo ""
+            echo "Version was auto-computed as a **PATCH** bump (\`${LATEST_TAG}\` -> \`v${VERSION}\`). If this batch of changes includes a breaking change (a removed flag, a changed output format — see the version-bump table in DEVELOPMENT.md), edit the \`## ${VERSION}\` heading in \`CHANGELOG.md\` to the next **MINOR** version before merging."
+            echo ""
+            echo "Merging this PR (with the \`release\` label, already applied) will trigger \`create-release.yml\` as usual — nothing is released until then."
+          } > pr-body.md
+
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --title "chore(release): v${VERSION}" \
+            --label release \
+            --body-file pr-body.md \
+            --head "$BRANCH" \
+            --base main

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -17,6 +17,10 @@ on:
     - cron: "9 8 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: release-cadence-check-${{ github.repository }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: read
@@ -38,22 +42,46 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -sSL -o git-cliff.tar.gz \
-            https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz
-          tar -xzf git-cliff.tar.gz
+          set -euo pipefail
+          ASSET="git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz"
+          BASE_URL="https://github.com/orhun/git-cliff/releases/download/v2.13.1"
+
+          curl -sSL -o "$ASSET" "${BASE_URL}/${ASSET}"
+          curl -sSL -o "${ASSET}.sha512" "${BASE_URL}/${ASSET}.sha512"
+          sha512sum -c "${ASSET}.sha512"
+
+          tar -xzf "$ASSET"
           sudo mv git-cliff-2.13.1/git-cliff /usr/local/bin/git-cliff
           git-cliff --version
 
       - name: Check for unreleased user-facing commits
         id: detect
         run: |
+          set -euo pipefail
           LATEST_TAG=$(git describe --tags --abbrev=0)
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
 
           # Reuses cliff.toml's own commit-type filtering (the same rules
           # `make changelog` uses) rather than re-deriving the feat/fix/docs/
           # perf/refactor/revert/test inclusion list a second time here.
-          NOTES=$(git-cliff "${LATEST_TAG}"..HEAD --unreleased --strip header --config cliff.toml 2>/dev/null | tr -d '[:space:]')
+          # Exit code is checked explicitly (rather than swallowing stderr
+          # and guessing from stdout content) so a git-cliff failure fails
+          # the job loudly instead of being silently misread as "nothing to
+          # release" or a false-positive "something to release". stdout and
+          # stderr are kept separate: git-cliff's INFO/WARN diagnostics go
+          # to stderr on every run (even successful ones), so merging them
+          # into the content check would make it permanently non-empty.
+          set +e
+          RAW=$(git-cliff "${LATEST_TAG}"..HEAD --unreleased --strip header --config cliff.toml 2>git-cliff-stderr.log)
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::git-cliff failed with exit code ${STATUS}:"
+            cat git-cliff-stderr.log
+            exit 1
+          fi
+
+          NOTES=$(echo "$RAW" | tr -d '[:space:]')
           if [ -z "$NOTES" ]; then
             echo "has_unreleased=false" >> "$GITHUB_OUTPUT"
           else
@@ -97,6 +125,15 @@ jobs:
           git add CHANGELOG.md
           git commit -m "chore(release): update CHANGELOG.md for v${VERSION}"
           git push --force-with-lease origin "$BRANCH"
+
+          # A prior run may have pushed this branch and opened a PR that was
+          # later closed without merging (e.g. rejected content) without the
+          # branch being deleted — matches create-release.yml's
+          # update-homebrew-tap job, which guards the same way.
+          if gh pr view --repo "${{ github.repository }}" "$BRANCH" >/dev/null 2>&1; then
+            echo "PR for \`$BRANCH\` already exists, skipping creation."
+            exit 0
+          fi
 
           {
             echo "Automated release PR — detected unreleased user-facing commits since \`${LATEST_TAG}\`."

--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ One CI gate will validate the PR:
 
 - **Changelog gate** — confirms `CHANGELOG.md` is modified when the `release` label is present.
 
+**Steps 1–2 can also happen automatically.** `.github/workflows/release-cadence-check.yml` runs weekly (and on manual `workflow_dispatch`) checking for unreleased user-facing commits on `main`; if it finds any, it runs `make changelog` and opens a release PR itself, defaulting to a PATCH version bump. It never merges, tags, or releases anything — step 3 below still requires a human to review and merge, exactly as if the PR had been opened by hand. If the auto-computed PATCH bump is wrong for a given batch of changes (i.e. it includes a breaking change), edit the version heading in the PR's `CHANGELOG.md` diff to the next MINOR version before merging.
+
 ### 3. Merge to trigger the release
 
 Merging the PR to `main` triggers `.github/workflows/create-release.yml` on that push. The workflow only performs a release when the **merged PR has the `release` label** (it checks linked PRs for that label); other pushes to `main` do not create tags or releases.

--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ One CI gate will validate the PR:
 
 **Steps 1–2 can also happen automatically.** `.github/workflows/release-cadence-check.yml` runs weekly (and on manual `workflow_dispatch`) checking for unreleased user-facing commits on `main`; if it finds any, it runs `make changelog` and opens a release PR itself, defaulting to a PATCH version bump. It never merges, tags, or releases anything — step 3 below still requires a human to review and merge, exactly as if the PR had been opened by hand. If the auto-computed PATCH bump is wrong for a given batch of changes (i.e. it includes a breaking change), edit the version heading in the PR's `CHANGELOG.md` diff to the next MINOR version before merging.
 
+Not the right time to release (e.g. other work is still landing and you'd rather batch it in)? Closing an auto-opened PR without merging is a normal way to defer — it isn't permanent, and the next scheduled run will propose a fresh PR if unreleased commits still remain.
+
 ### 3. Merge to trigger the release
 
 Merging the PR to `main` triggers `.github/workflows/create-release.yml` on that push. The workflow only performs a release when the **merged PR has the `release` label** (it checks linked PRs for that label); other pushes to `main` do not create tags or releases.

--- a/scripts/changelog/main.go
+++ b/scripts/changelog/main.go
@@ -6,6 +6,7 @@
 //	go run ./scripts/changelog extract --section next --strip-comments
 //	go run ./scripts/changelog extract-version
 //	go run ./scripts/changelog validate-version 0.1.0
+//	go run ./scripts/changelog next-version --bump patch 0.1.0
 //	go run ./scripts/changelog merge --manual MANUAL.md --generated CLIFF.md --output MERGED.md
 //	go run ./scripts/changelog update --version 0.1.0 --notes NOTES.md
 package main
@@ -19,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -32,7 +34,7 @@ var (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: changelog <extract|extract-version|validate-version|merge|update|transform> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: changelog <extract|extract-version|validate-version|next-version|merge|update|transform> [flags]")
 		os.Exit(1)
 	}
 
@@ -46,6 +48,8 @@ func main() {
 		runExtractVersion()
 	case "validate-version":
 		runValidateVersion()
+	case "next-version":
+		runNextVersion()
 	case "merge":
 		runMerge()
 	case "update":
@@ -120,6 +124,55 @@ func runValidateVersion() {
 		fmt.Fprintf(os.Stderr, "validate-version: %q is invalid — use strict semver x.y.z with digits only (e.g. 0.0.61, not v0.0.61)\n", v)
 		os.Exit(1)
 	}
+}
+
+// NextVersion computes the version after current for the given bump type
+// ("patch" or "minor"). current must be strict x.y.z (no v prefix); bumping
+// minor resets patch to 0.
+func NextVersion(current, bump string) (string, error) {
+	if !StrictSemver(current) {
+		return "", fmt.Errorf("%q is invalid — use strict semver x.y.z with digits only (e.g. 0.0.61, not v0.0.61)", current)
+	}
+
+	parts := strings.Split(current, ".")
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	patch, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return "", fmt.Errorf("%q could not be parsed as major.minor.patch", current)
+	}
+
+	switch bump {
+	case "patch":
+		patch++
+	case "minor":
+		minor++
+		patch = 0
+	default:
+		return "", fmt.Errorf("unknown bump type %q — use patch or minor", bump)
+	}
+
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch), nil
+}
+
+func runNextVersion() {
+	fs := flag.NewFlagSet("next-version", flag.ContinueOnError)
+	bump := fs.String("bump", "patch", "version segment to bump: patch or minor")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "next-version: %v\n", err)
+		os.Exit(1)
+	}
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "next-version: current version argument required (strict x.y.z, no v prefix)")
+		os.Exit(1)
+	}
+
+	next, err := NextVersion(strings.TrimSpace(fs.Arg(0)), *bump)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "next-version: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Print(next)
 }
 
 func runExtractVersion() {

--- a/scripts/changelog/main_test.go
+++ b/scripts/changelog/main_test.go
@@ -138,6 +138,41 @@ func TestStrictSemver(t *testing.T) {
 	}
 }
 
+func TestNextVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		bump    string
+		want    string
+		wantErr bool
+	}{
+		{"patch bump", "1.2.1", "patch", "1.2.2", false},
+		{"minor bump resets patch", "1.2.1", "minor", "1.3.0", false},
+		{"patch bump at zero", "0.0.0", "patch", "0.0.1", false},
+		{"multi digit segments", "10.20.30", "patch", "10.20.31", false},
+		{"v prefix rejected", "v1.2.1", "patch", "", true},
+		{"empty rejected", "", "patch", "", true},
+		{"unknown bump type rejected", "1.2.1", "major", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NextVersion(tt.current, tt.bump)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NextVersion(%q, %q) expected error, got %q", tt.current, tt.bump, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NextVersion(%q, %q) unexpected error: %v", tt.current, tt.bump, err)
+			}
+			if got != tt.want {
+				t.Errorf("NextVersion(%q, %q) = %q, want %q", tt.current, tt.bump, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractSection(t *testing.T) {
 	changelog := `# CHANGELOG
 


### PR DESCRIPTION
## Summary

Automates steps 1-2 of README's "Release Process" (generate changelog, open a labeled PR) — today a human has to notice unreleased commits and run `make changelog` manually. Never merges, tags, or releases anything itself; `create-release.yml` is unchanged and still gates on a human-approved merge with the `release` label.

## What changed

- `.github/workflows/release-cadence-check.yml`: weekly (+ `workflow_dispatch`), detects unreleased user-facing commits via `orhun/git-cliff-action` (SHA-pinned), reusing `cliff.toml`'s own filtering rules. Skips if a PR for that release branch is still open. Closing one without merging is a deliberate "not yet" — not a permanent block — the next run re-proposes a fresh PR if unreleased work remains. Has a `concurrency` group.
- New `scripts/changelog next-version` subcommand (+ tests): defaults to PATCH per this repo's version-bump table, deliberately ignoring `git-cliff --bumped-version`'s standard-semver suggestion (verified it suggests `v1.3.0`; `v1.2.2` is correct here since nothing unreleased is breaking). PR body tells a human to bump to MINOR manually if needed. Also tagged `dct-ready-for-review` — DCT owns CLI releases for now, so this reuses the existing Slack notification the label already triggers.
- README.md documents it inline in the existing Release Process section, including that closing an auto-opened PR is a normal way to defer a release.

## Security

Schedule/`workflow_dispatch` only, never `pull_request`/`pull_request_target`. `secrets.REPO_CONTENTS_WRITE` is already restricted to the `main` branch via the environment's deployment policy. `latest_tag` is validated against `^vX.Y.Z$` before use anywhere, including as an expression passed into `git-cliff-action`'s `args` input — closes a defense-in-depth script-injection gap (needs write access to exploit already, not an open hole).

## Governance

This doesn't change who decides to release, only who notices there's something to release. Same branch protection (1 approval + passing build) gates the merge; same reviewers decide. Multi-team partial work is handled by closing the PR — that's a snooze, not a rejection.

## Testing

Verified end-to-end locally against `main`'s real unreleased commits: detection, version computation (`1.2.2`), and `make changelog` all correct. `next-version` has unit tests. `make test`/`make lint`/`actionlint` pass.

Full live test (real PR creation) needs a merge first — `environment: main`'s branch policy blocks the job from a feature branch. Post-merge: `gh workflow run release-cadence-check.yml --repo prolific-oss/cli --ref main`.

