### PR TITLE
fix(DCT-285): truncate oversized API error details in CLI output

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/prolific-oss/cli/agentenv"
 	"github.com/prolific-oss/cli/config"
@@ -148,7 +149,29 @@ type UnrecognizedAPIError struct {
 }
 
 func (e *UnrecognizedAPIError) Error() string {
-	return fmt.Sprintf("request failed with status %d: %s", e.StatusCode, string(e.Body))
+	return fmt.Sprintf("request failed with status %d: %s", e.StatusCode, truncateErrorDetail(string(e.Body)))
+}
+
+// maxErrorDetailLen caps upstream API error text shown to the user; the full response is available via PROLIFIC_DEBUG=1.
+const maxErrorDetailLen = 500
+
+// truncateErrorDetail returns a copy; it never mutates the caller's data (e.g. UnrecognizedAPIError.Body).
+func truncateErrorDetail(s string) string {
+	if utf8.RuneCountInString(s) <= maxErrorDetailLen {
+		return s
+	}
+
+	cut := len(s)
+	runeCount := 0
+	for i := range s {
+		if runeCount == maxErrorDetailLen {
+			cut = i
+			break
+		}
+		runeCount++
+	}
+
+	return fmt.Sprintf("%s... [truncated, %d of %d bytes shown; re-run with PROLIFIC_DEBUG=1 for the full response]", s[:cut], cut, len(s))
 }
 
 // Client is responsible for interacting with the Prolific API.
@@ -249,13 +272,13 @@ func (c *Client) Execute(method, url string, body any, response any) (*http.Resp
 		// Try the nested error format first
 		var apiError JSONAPIError
 		if err := json.NewDecoder(io.NopCloser(bytes.NewBuffer(responseBody))).Decode(&apiError); err == nil && apiError.Error.Detail != nil {
-			return nil, fmt.Errorf("request failed: %v", apiError.Error.Detail)
+			return nil, fmt.Errorf("request failed: %s", truncateErrorDetail(fmt.Sprintf("%v", apiError.Error.Detail)))
 		}
 
 		// Try the simple error format
 		var simpleError SimpleAPIError
 		if err := json.NewDecoder(io.NopCloser(bytes.NewBuffer(responseBody))).Decode(&simpleError); err == nil && simpleError.Detail != "" {
-			return nil, fmt.Errorf("request failed: %s - %s", simpleError.Message, simpleError.Detail)
+			return nil, fmt.Errorf("request failed: %s - %s", simpleError.Message, truncateErrorDetail(simpleError.Detail))
 		}
 
 		// If both fail, return a typed error so callers can inspect the raw body

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -64,6 +67,151 @@ func TestFormatBatchErrorBody(t *testing.T) {
 				t.Fatalf("expected:\n%q\ngot:\n%q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestExecuteTruncatesOversizedErrorDetail(t *testing.T) {
+	oversizedDetail := strings.Repeat("x", maxErrorDetailLen*3)
+
+	tests := []struct {
+		name          string
+		statusCode    int
+		body          string
+		wantTruncated bool
+	}{
+		{
+			name:          "JSONAPIError with oversized detail is truncated and hints at debug mode",
+			statusCode:    http.StatusBadRequest,
+			body:          fmt.Sprintf(`{"error":{"status":400,"title":"Bad Request","detail":%q}}`, oversizedDetail),
+			wantTruncated: true,
+		},
+		{
+			name:          "JSONAPIError with small detail is unchanged",
+			statusCode:    http.StatusBadRequest,
+			body:          `{"error":{"status":400,"title":"Bad Request","detail":"study ID is invalid"}}`,
+			wantTruncated: false,
+		},
+		{
+			name:          "SimpleAPIError with oversized detail is truncated and hints at debug mode",
+			statusCode:    http.StatusBadRequest,
+			body:          fmt.Sprintf(`{"message":"Bad Request","detail":%q}`, oversizedDetail),
+			wantTruncated: true,
+		},
+		{
+			name:          "SimpleAPIError with small detail is unchanged",
+			statusCode:    http.StatusBadRequest,
+			body:          `{"message":"Bad Request","detail":"study not found"}`,
+			wantTruncated: false,
+		},
+		{
+			name:          "unrecognized error body is truncated and hints at debug mode",
+			statusCode:    http.StatusInternalServerError,
+			body:          strings.Repeat("y", maxErrorDetailLen*3),
+			wantTruncated: true,
+		},
+		{
+			name:          "small unrecognized error body is unchanged",
+			statusCode:    http.StatusInternalServerError,
+			body:          "internal server error",
+			wantTruncated: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			c := Client{Client: server.Client(), BaseURL: server.URL, Token: "test-token"}
+
+			_, err := c.Execute(http.MethodGet, "/", nil, nil)
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+
+			if tt.wantTruncated {
+				if !strings.Contains(err.Error(), "PROLIFIC_DEBUG=1") {
+					t.Fatalf("expected truncated error to mention PROLIFIC_DEBUG=1, got: %q", err.Error())
+				}
+				if len(err.Error()) >= len(tt.body) {
+					t.Fatalf("expected error message to be shorter than the oversized body (%d bytes), got %d bytes", len(tt.body), len(err.Error()))
+				}
+			} else {
+				if strings.Contains(err.Error(), "PROLIFIC_DEBUG=1") {
+					t.Fatalf("expected small error not to be truncated, got: %q", err.Error())
+				}
+			}
+		})
+	}
+}
+
+// TestTruncateErrorDetailMultiByteRuneCount guards against comparing byte length to a rune-based cap.
+func TestTruncateErrorDetailMultiByteRuneCount(t *testing.T) {
+	// 300 runes of a 3-byte CJK character: 900 bytes, but only 300 runes.
+	s := strings.Repeat("世", 300)
+
+	got := truncateErrorDetail(s)
+
+	if got != s {
+		t.Fatalf("expected a string under the rune cap to be returned unchanged, got: %q", got)
+	}
+}
+
+// TestUnrecognizedAPIErrorBodyRemainsIntactAfterTruncation guards the INVALID_BATCH_ITEMS path's json.Unmarshal of Body.
+func TestUnrecognizedAPIErrorBodyRemainsIntactAfterTruncation(t *testing.T) {
+	issue := struct {
+		Page    int    `json:"page"`
+		Row     int    `json:"row"`
+		Column  int    `json:"column"`
+		Item    int    `json:"item"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}{Message: strings.Repeat("z", maxErrorDetailLen*3)}
+
+	payload := struct {
+		Type   string        `json:"type"`
+		Issues []interface{} `json:"issues"`
+	}{Type: "INVALID_BATCH_ITEMS", Issues: []interface{}{issue}}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal fixture: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	c := Client{Client: server.Client(), BaseURL: server.URL, Token: "test-token"}
+
+	_, execErr := c.Execute(http.MethodGet, "/", nil, nil)
+	if execErr == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+
+	var apiErr *UnrecognizedAPIError
+	if !errors.As(execErr, &apiErr) {
+		t.Fatalf("expected *UnrecognizedAPIError, got %T: %v", execErr, execErr)
+	}
+
+	if !bytes.Equal(apiErr.Body, body) {
+		t.Fatalf("UnrecognizedAPIError.Body was mutated/truncated: got %d bytes, want %d bytes", len(apiErr.Body), len(body))
+	}
+
+	got := formatBatchErrorBody(apiErr.Body)
+	if !strings.Contains(got, issue.Message) {
+		t.Fatalf("formatBatchErrorBody lost the full untruncated message; got %d chars, want to contain %d-char message", len(got), len(issue.Message))
+	}
+
+	if !strings.Contains(apiErr.Error(), "PROLIFIC_DEBUG=1") {
+		t.Fatalf("expected Error() to be truncated with a debug hint, got: %q", apiErr.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

GitHub issue #416 reported the CLI dumping hundreds of lines as an error message for a simple invalid-ID lookup. A live reproduction against production `api.prolific.com` confirmed it: for `study view badid`, the API's own `detail` field contains a ~200KB raw Django URL-resolver debug dump, which `Client.Execute` relayed verbatim with no length cap — across all three of its error-parsing branches.

## What changed

- `client/client.go`: new `truncateErrorDetail` helper (500-rune cap, hints at `PROLIFIC_DEBUG=1` for the full response), applied to the `JSONAPIError`, `SimpleAPIError`, and `UnrecognizedAPIError.Error()` formatting paths.
- Critical constraint preserved: only the *string* returned by `.Error()` is truncated — `UnrecognizedAPIError.Body` itself is left fully intact, since `UpdateAITaskBuilderBatch`/`CreateAITaskBuilderBatch` `json.Unmarshal` it via `errors.As` to extract `INVALID_BATCH_ITEMS` details.
- Debug mode (`PROLIFIC_DEBUG=1`) is unaffected — it already prints the full raw response before any error formatting runs.
- Caps by rune count (`utf8.RuneCountInString`), not byte length — a multi-byte UTF-8 string can exceed the byte cap while having far fewer runes, which previously produced a false "truncated" suffix on an untouched string.

## Testing

- New table-driven tests covering all three error branches, each with an oversized and a small-input case (no regression for normal-sized errors).
- A dedicated regression test proving `UnrecognizedAPIError.Body` stays byte-for-byte intact and still `json.Unmarshal`-able after truncation is applied to `.Error()`.
- A multi-byte case (`TestTruncateErrorDetailMultiByteRuneCount`) locking in the rune-vs-byte fix above.
- Verified live against production: `study view badid` output dropped from ~580KB to ~1.8KB; `PROLIFIC_DEBUG=1 study view badid` unchanged (full response still printed).
- `go test ./...` and `make lint` pass.

Closes #416.

