### PR TITLE
feat(DCT-262): detect API schema drift, add fix-assist skill

### DIFF
--- a/.claude/skills/schema-drift-fix/SKILL.md
+++ b/.claude/skills/schema-drift-fix/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: schema-drift-fix
+description: Check the CLI against the live Prolific API spec for drift (optionally starting from a filed schema-drift issue) and propose the client-code fix, following AGENTS.md's API-method checklist. Human reviews and commits.
+argument-hint: "[issue-number]"
+user-invocable: true
+---
+
+# Schema Drift Fix
+
+## When to Use This Skill
+
+Invoke this skill when the user:
+- References a `schema-drift`-labeled issue
+- Asks to "fix schema drift", "check for API drift", or similar
+- Uses the slash command /schema-drift-fix
+
+---
+
+Check whether the CLI's `client` package still matches the live Prolific API spec, and propose the fix if it doesn't — following the same checklist a human would use when adding a new API method. This skill investigates and drafts; it does not commit, push, or open a PR. The engineer reviews and does that themselves.
+
+## Arguments
+
+`issue-number` (optional) — a `schema-drift` issue filed by `.github/workflows/schema-drift-check.yml`.
+
+This skill does not depend on an issue existing. An issue is a convenient shortcut when CI already found and described drift, but the real source of truth is always a fresh `go test ./contract_test/...` run (Phase 1, step 1) — an issue's captured output can be stale by the time someone picks it up.
+
+- If `issue-number` is given: `gh issue view <issue-number> --json title,body,state` — confirm it's an open issue with a title matching `API schema drift detected (...)`, and use its body as corroborating context.
+- If omitted: skip the issue lookup entirely and just run the check directly. This is the default, everyday way to invoke this skill — proactively, not only after CI has already filed something.
+
+## Phase 1: Investigate
+
+1. Run `go test ./contract_test/...` locally (this downloads the live Prolific OpenAPI spec itself, same as the workflow). If it passes: report "no drift detected" and stop here — there's nothing to do, regardless of whether an issue was given. If it fails, continue.
+2. If an issue number was given, cross-check its body against this fresh result — same operation(s) failing? Anything CI's snapshot called out that isn't reproducing now? Flag any mismatch rather than trusting either source silently.
+3. Identify which operation(s)/test case(s) are failing from the fresh output.
+4. Cross-reference `contract_test/contract_test.go`'s `operations` table entry for the affected operation(s) against the live spec to determine exactly what changed (new/renamed/removed field, changed type, new required param, etc.).
+
+## Phase 2: Present Plan Summary
+
+Before touching any code, present:
+1. Which operation(s) drifted and how (a concrete old-shape vs. new-shape diff)
+2. Which files will change
+3. Whether this looks like a routine mechanical update or something structurally bigger — this automation is meant for small changes like a new/renamed field, not architectural redesigns. Flag it explicitly if it looks like the latter rather than plowing ahead.
+
+**Ask for explicit approval before Phase 3.**
+
+## Phase 3: Implement
+
+Follow the "Adding a New Command" checklist in `AGENTS.md` (step 7, "If new API methods are needed") — the same checklist `schema-drift-check.yml`'s filed issue paraphrases:
+
+1. Update the `API` interface in `client/client.go` and implement on the `Client` struct
+2. Add/update request/response structs in `client/payloads.go`/`client/responses.go`
+3. Run `make test-gen-mock`
+4. Update the relevant entry in `contract_test/contract_test.go`'s `operations` table
+5. Run `make readme-coverage`
+
+Repeat per affected operation if more than one drifted.
+
+## Phase 4: Verify
+
+1. `go test ./contract_test/...` — confirm the specific drift is resolved
+2. `make test`
+3. `make lint`
+
+Report results.
+
+## Phase 5: Hand Back to the Human
+
+This skill never commits, pushes, or opens a PR. Summarize what changed; if an issue number was given, point back to it so the engineer can reference it in their own commit message and close it themselves once merged. Every write action from here stays human-initiated.
+
+## Reference Patterns
+
+| Pattern | Reference File |
+|---------|----------------|
+| Schema drift detection workflow | `.github/workflows/schema-drift-check.yml` |
+| Adding a New API Method checklist | `AGENTS.md` — "Adding a New Command", step 7 |
+| Contract test operations table | `contract_test/contract_test.go` |
+| Client method example | `client/client.go` |
+
+$ARGUMENTS

--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -1,0 +1,81 @@
+name: Schema Drift Check
+
+# Runs contract_test against the LIVE Prolific API spec on a schedule and files an issue on failure — see AGENTS.md's Schema Drift Detection section.
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: schema-drift-check-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version: 1.26.5
+
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Get dependencies
+        run: make install
+
+      - name: Run contract tests against the live API spec
+        id: contract_test
+        run: |
+          # No -v: it buries the failure signal under passing-subtest noise (verified: 11.5KB vs 355 bytes for the same failure).
+          go test ./contract_test/... > contract-test-output.txt 2>&1 || true
+          if grep -q "^FAIL" contract-test-output.txt; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an already-open schema-drift issue
+        if: steps.contract_test.outputs.drift == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh issue list --repo "${{ github.repository }}" --label schema-drift --state open --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: File a schema-drift issue
+        if: steps.contract_test.outputs.drift == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "Contract tests (\`go test ./contract_test/...\`) failed against the live Prolific OpenAPI spec — this usually means the API has changed in a way the CLI doesn't yet handle."
+            echo ""
+            echo "## Failing test output"
+            echo ""
+            echo '```'
+            cat contract-test-output.txt
+            echo '```'
+            echo ""
+            echo "## What likely needs to change"
+            echo ""
+            echo "Follow AGENTS.md's \"Adding a New API Method\" checklist:"
+            echo ""
+            echo "- [ ] Update the \`API\` interface in \`client/client.go\` and implement on the \`Client\` struct"
+            echo "- [ ] Add/update request/response structs in \`client/payloads.go\`/\`client/responses.go\`"
+            echo "- [ ] Run \`make test-gen-mock\` to regenerate \`mock_client/mock_client.go\`"
+            echo "- [ ] Update the relevant entry (or entries) in \`contract_test/contract_test.go\`'s \`operations\` table"
+            echo "- [ ] Run \`make readme-coverage\` to refresh the API coverage table in \`README.md\`"
+            echo "- [ ] \`make test\` and \`make lint\` pass"
+          } > issue-body.md
+
+          gh issue create --repo "${{ github.repository }}" \
+            --title "API schema drift detected ($(date -u +%Y-%m-%d))" \
+            --label schema-drift \
+            --body-file issue-body.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,16 @@ This uses `git-cliff` (must be installed separately: `brew install git-cliff`) p
 
 To include hand-written notes in the next release, add them under `## next` in `CHANGELOG.md` before running `make changelog` — they will be merged in automatically.
 
+## Schema Drift Detection
+
+`.github/workflows/schema-drift-check.yml` runs `contract_test` (see `contract_test/contract_test.go`) daily on a schedule, independent of any push/PR activity, so drift is caught even when nothing else in the repo changes. `contract_test` already downloads the *live* Prolific OpenAPI spec on every run — this workflow just gives it a reason to run on its own.
+
+On failure, it files a GitHub issue labeled `schema-drift` with the exact failing test output and a checklist mirroring "Adding a New API Method" above. It skips filing if an open `schema-drift` issue already exists, so a persistent unresolved drift doesn't spam a new issue every day.
+
+Trigger it manually to test: `gh workflow run schema-drift-check.yml`.
+
+**No auto-assignment:** filed issues aren't auto-assigned to anyone. Auto-assigning to GitHub Copilot coding agent was investigated but requires org-level access this repo doesn't currently have (`"Bot does not have access to the repository"`, confirmed via the GraphQL `replaceActorsForAssignable` mutation) — and separately, running any unattended AI agent against a public repo's issues/PRs raises its own governance questions (prompt-injection surface from public issue content, unattended write access) that are unresolved regardless of which agent. Until that's settled, a human picks up filed issues — the `/schema-drift-fix` skill (`.claude/skills/schema-drift-fix/`) speeds that up by investigating and drafting the fix; it never commits, pushes, or opens a PR itself.
+
 ## Boundaries
 
 **Always do:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,4 @@
 ## Slash Commands
 
 - `/cli-command-create` — automates the full workflow for adding a new CLI command (see `.claude/skills/cli-command-create/`)
+- `/schema-drift-fix` — checks the CLI against the live API spec for drift and drafts the fix, optionally starting from a filed `schema-drift` issue (see `.claude/skills/schema-drift-fix/`)


### PR DESCRIPTION
## Summary

DCT-262: detect API schema drift on a schedule and file an issue, plus a human-run skill to speed up investigating and fixing it. Combines what was originally #492 (detection) and this PR (the fix skill) — closing #492 in favor of this one since the skill depends on the detection workflow anyway.

The original plan was to auto-assign filed issues to an AI coding agent to open a fix PR unattended. Blocked: Copilot has no access to this public repo, and a follow-up SecOps thread found no org policy yet for unattended AI agents on public repos — self-hosting the same idea via a GitHub Action wouldn't avoid that, just skip the approval checkpoint. Pivoted to a human-run skill instead.

## What changed

- `.github/workflows/schema-drift-check.yml` (new): runs `contract_test` daily on a schedule (+ `workflow_dispatch`), independent of push/PR activity. On failure, files a `schema-drift`-labeled issue with the failing test output and a checklist mirroring `AGENTS.md`'s "Adding a New Command" steps. Skips filing if one's already open.
- `.claude/skills/schema-drift-fix/SKILL.md` (new): checks the CLI against the live spec (works standalone with no argument — the default, everyday path — or optionally starting from a filed issue number for context), identifies what changed, proposes the fix following the same AGENTS.md checklist, then stops — no commit, push, or PR from the skill itself.
- `AGENTS.md`: documents both — the detection workflow, and a "No auto-assignment" note pointing at the skill instead of the parked Copilot blocker.
- `CLAUDE.md`: registers `/schema-drift-fix` alongside the existing `/cli-command-create` skill.

## Testing

- Verified drift-detection locally against both a clean state and a deliberately corrupted `contract_test.go` entry (correctly detects and produces a clean, actionable issue body). `actionlint` passes on the workflow YAML.
- Manually ran `/schema-drift-fix` with no argument against the live API — correctly reported no drift and stopped.
- `make test`/`make lint` pass.
