### PR TITLE
fix(DCT-262): read Go version from go.mod in schema-drift-check

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -18,13 +18,13 @@ jobs:
   check-drift:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
       - name: Set up Go
         uses: actions/setup-go@v7.0.0
         with:
-          go-version: 1.26.5
-
-      - name: Check out code
-        uses: actions/checkout@v7
+          go-version-file: go.mod
 
       - name: Get dependencies
         run: make install


### PR DESCRIPTION
## Summary

Today's scheduled run of `schema-drift-check.yml` failed before ever reaching the contract test: https://github.com/prolific-oss/cli/actions/runs/32339844741/job/96336560397

Root cause: `go.mod` requires `go >= 1.26.6` (bumped in #494, after this workflow was written), but the workflow still pinned `go-version: 1.26.5` explicitly. `actions/setup-go` sets `GOTOOLCHAIN=local` when a version is pinned, so it refuses to silently fetch the newer toolchain — `go install ./cmd/prolific` (via `make install`) hard-failed immediately.

## Fix

Instead of a literal version (which will drift out of sync again next time `go.mod` bumps, same as this time), use `go-version-file: go.mod` so the workflow always tracks whatever `go.mod` currently requires. This needs checkout before setup-go so the file actually exists to read — previously reversed, which is also why `setup-go`'s dependency-cache step was silently warning "Dependencies file is not found" on every run (harmless on its own, but the same underlying ordering issue).

## Testing

`actionlint` passes. `make test`/`make lint` pass. Will also manually trigger `workflow_dispatch` after this merges to confirm the fix works end-to-end.
