### PR TITLE
fix(DCT-262): read Go version from go.mod in release-cadence-check

### DIFF
--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7.0.0
         with:
-          go-version: 1.26.5
+          go-version-file: go.mod
 
       - name: Get latest tag
         id: tag


### PR DESCRIPTION
## Summary

The scheduled `release-cadence-check` run failed: go.mod requires Go 1.26.6 (bumped since this workflow was written) but the workflow still pinned Go 1.26.5, and `GOTOOLCHAIN=local` refuses to silently fetch a newer one. Same root cause fixed for `schema-drift-check` in #498.

## Fix

Use `go-version-file: go.mod` instead of a literal version in `actions/setup-go`, so the pinned Go version can't drift out of sync with go.mod again. Checkout already runs before setup-go in this workflow, so no step reordering was needed here.

## Testing

- Workflow YAML change only, no application code affected — `make lint`/`make test` pass via the pre-commit hook.