### PR TITLE
fix(DCT-262): authenticate checkout with write token in release-cadence-check

### DIFF
--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.REPO_CONTENTS_WRITE }}
 
       - name: Set up Go
         uses: actions/setup-go@v7.0.0

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPO_CONTENTS_WRITE }}
 
       - name: Set up Go
         uses: actions/setup-go@v7.0.0
@@ -130,6 +129,13 @@ jobs:
           git checkout -b "$BRANCH"
           git add CHANGELOG.md
           git commit -m "chore(release): update CHANGELOG.md for v${VERSION}"
+
+          # Re-authenticate with the write-scoped token only now, right
+          # before the one command in this job that needs it — checkout
+          # deliberately stays on the default read-only GITHUB_TOKEN so
+          # this credential is never on disk while earlier steps (including
+          # the third-party git-cliff action) run.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push --force-with-lease origin "$BRANCH"
 
           # Only skip if a PR for this branch is still OPEN. A closed


### PR DESCRIPTION
## Summary

After fixing the Go version drift (#502), the workflow got further but hit a new failure in the "Open a release PR" step:

```
remote: Permission to prolific-oss/cli.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/prolific-oss/cli/': The requested URL returned error: 403
```

## Root cause

`git push` relies on the credentials `actions/checkout` persists at the start of the job. Those default to `GITHUB_TOKEN`, which this workflow scopes to `contents: read` / `pull-requests: read`. The step's `GH_TOKEN: ${{ secrets.REPO_CONTENTS_WRITE }}` env var only affects `gh` CLI calls (like `gh pr create`) — it has no effect on a raw `git push`.

## Fix

An earlier version of this PR passed `token: ${{ secrets.REPO_CONTENTS_WRITE }}` to the initial `actions/checkout` step, matching how `create-release.yml` does it. A security review caught a problem with that: unlike every job in `create-release.yml`, this job runs a third-party composite action (`orhun/git-cliff-action`) *between* checkout and the push. That action downloads and executes a git-cliff release binary with no checksum or signature verification — code with full filesystem access to `.git/config`, where the write-scoped credential would sit for the whole job on every run (including the common case where nothing ends up pushed).

Instead, checkout stays on the default read-only `GITHUB_TOKEN`, and the write-scoped token is swapped into the remote URL only immediately before the one `git push` that needs it:

```sh
git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
git push --force-with-lease origin "$BRANCH"
```

This keeps the elevated credential off disk while git-cliff (and everything else earlier in the job) runs.

## Testing

- Workflow YAML change only. Will validate by re-running `release-cadence-check.yml` via `workflow_dispatch` once this merges.