### PR TITLE
fix(DCT-262): disable checkout's persisted credentials in release-cadence-check

### DIFF
--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v7.0.0


### PR DESCRIPTION
## Summary

PR #503's fix didn't actually work when tested live: the push still authenticated as `github-actions[bot]` and failed with the same 403.

```
remote: Permission to prolific-oss/cli.git denied to github-actions[bot].
```

## Root cause

`actions/checkout` persists the default `GITHUB_TOKEN` as a git credential by writing `http.https://github.com/.extraheader` into the local git config (this is the `persist-credentials: true` default). That extraheader applies to every request to `github.com`, regardless of what's embedded in the remote URL — so `git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/...` from #503 never actually took effect. Git kept authenticating with the extraheader's `GITHUB_TOKEN`, which this workflow scopes to `contents: read`, hence the 403.

## Fix

Add `persist-credentials: false` to the initial checkout step. Nothing before the push needs authenticated git access — `git describe`, git-cliff's changelog generation, and the "already-open PR" check (which uses `gh` with its own `GH_TOKEN` env var, not git's persisted credential) are all either local or use `gh` directly. With no extraheader written, the `git remote set-url` swap right before `git push` is the only credential in play.

## Testing

- Verified live: `workflow_dispatch` run before this fix failed with the 403 above. Will re-run after this merges to confirm the push succeeds.