### PR TITLE
feat(DCT-300): add eligibility-count command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Operations are grouped as they appear in [`contract_test/contract_test.go`](cont
 |---|---|---|---|
 | `get-filters` | GET | `/api/v1/filters/` | ✅ `GetFilters` |
 | `get-filter-distribution` | GET | `/api/v1/filters/{id}/distribution/` | ➖ Not exposed in the CLI |
-| `get-eligible-count` | POST | `/api/v1/eligibility-count/` | ➖ Not exposed in the CLI |
+| `get-eligible-count` | POST | `/api/v1/eligibility-count/` | ✅ `GetEligibilityCount` |
 
 </details>
 

--- a/client/client.go
+++ b/client/client.go
@@ -90,6 +90,7 @@ type API interface {
 	CreateTestParticipant(email string) (*CreateTestParticipantResponse, error)
 
 	GetFilters() (*ListFiltersResponse, error)
+	GetEligibilityCount(payload EligibilityCountPayload) (*EligibilityCountResponse, error)
 
 	GetRewardRecommendations(workspaceID, currency string, screenerIDs []string) (*RewardRecommendationsResponse, error)
 
@@ -999,6 +1000,25 @@ func (c *Client) GetFilters() (*ListFiltersResponse, error) {
 
 	url := "/api/v1/filters/"
 	if _, err := c.ExecuteBuilder().Get(url, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// GetEligibilityCount returns the number of participants matching a set of
+// filters, without creating a study.
+func (c *Client) GetEligibilityCount(payload EligibilityCountPayload) (*EligibilityCountResponse, error) {
+	var response EligibilityCountResponse
+
+	const url = "/api/v1/eligibility-count/"
+	_, err := c.ExecuteBuilder().
+		PostRequest(url).
+		Body(payload).
+		Status(http.StatusOK).
+		Decode(&response).
+		Execute()
+	if err != nil {
 		return nil, err
 	}
 

--- a/client/payloads.go
+++ b/client/payloads.go
@@ -1,6 +1,17 @@
 package client
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/prolific-oss/cli/model"
+)
+
+// EligibilityCountPayload represents the JSON payload for counting how many
+// participants match a set of filters, without creating a study.
+type EligibilityCountPayload struct {
+	Filters     []model.Filter `json:"filters"`
+	WorkspaceID string         `json:"workspace_id,omitempty"`
+}
 
 // SendMessagePayload represents the JSON payload for sending a message.
 type SendMessagePayload struct {

--- a/client/responses.go
+++ b/client/responses.go
@@ -83,6 +83,14 @@ type ListFiltersResponse struct {
 	*JSONAPIMeta
 }
 
+// EligibilityCountResponse is the response for the eligibility count
+// endpoint. Counts below 25 are floored to 0 by the API to protect
+// participant privacy, so a Count of 0 does not necessarily mean zero
+// eligible participants.
+type EligibilityCountResponse struct {
+	Count int `json:"count"`
+}
+
 // RewardRecommendationsResponse is the response for the reward
 // recommendations endpoint. The API guarantees the first item is the most
 // recent set of rates.

--- a/cmd/eligibilitycount/count.go
+++ b/cmd/eligibilitycount/count.go
@@ -1,0 +1,109 @@
+package eligibilitycount
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/model"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// CountOptions is the options for the eligibility-count command.
+type CountOptions struct {
+	TemplatePath string
+	WorkspaceID  string
+}
+
+// countTemplate is the shape of the -t/--template-path file: a flat list of
+// filters, the same format `study create` accepts. Composite (and/or) filter
+// groups, which the API also supports, are not represented here.
+type countTemplate struct {
+	Filters []model.Filter `mapstructure:"filters"`
+}
+
+// NewCountCommand creates a new `eligibility-count` command to count how many
+// participants match a set of filters, without creating a study.
+func NewCountCommand(client client.API, w io.Writer) *cobra.Command {
+	var opts CountOptions
+
+	cmd := &cobra.Command{
+		Use:   "eligibility-count",
+		Short: "Count participants matching a set of filters",
+		Long: `Count how many participants would be eligible for a study defined by a
+set of filters, without creating the study.
+
+Counts below 25 are reported as 0 by the Prolific API, to protect
+participant privacy. A count of 0 may mean either "zero eligible" or
+"somewhere between 1 and 24 eligible" — the CLI cannot tell these apart.`,
+		Example: `
+Count participants matching the filters in a JSON/YAML file (see
+"prolific study create --help" for the filter format)
+$ prolific eligibility-count -t /path/to/filters.json -w <workspace-id>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.TemplatePath == "" {
+				return fmt.Errorf("error: a filter template is required, use -t/--template-path")
+			}
+
+			if opts.WorkspaceID == "" {
+				return fmt.Errorf("error: workspace ID is required")
+			}
+
+			count, err := getEligibilityCount(client, opts)
+			if err != nil {
+				return fmt.Errorf("error: %s", err)
+			}
+
+			fmt.Fprintln(w, RenderCount(count))
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.TemplatePath, "template-path", "t", "", "Path to a YAML/JSON file containing the filters to count against")
+	flags.StringVarP(&opts.WorkspaceID, "workspace", "w", viper.GetString("workspace"), "The workspace ID to count eligible participants for (required).")
+
+	return cmd
+}
+
+func getEligibilityCount(c client.API, opts CountOptions) (int, error) {
+	v := viper.New()
+	v.SetConfigFile(opts.TemplatePath)
+	if err := v.ReadInConfig(); err != nil {
+		return 0, err
+	}
+
+	var tmpl countTemplate
+	if err := v.Unmarshal(&tmpl); err != nil {
+		return 0, fmt.Errorf("unable to map %s to filters: %s", opts.TemplatePath, err)
+	}
+
+	// The API requires "filters" to be present and non-null, even when empty.
+	if tmpl.Filters == nil {
+		tmpl.Filters = []model.Filter{}
+	}
+
+	response, err := c.GetEligibilityCount(client.EligibilityCountPayload{
+		Filters:     tmpl.Filters,
+		WorkspaceID: opts.WorkspaceID,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return response.Count, nil
+}
+
+// RenderCount produces a human-readable line for an eligibility count,
+// flagging the sub-25 privacy floor explicitly rather than presenting 0 as
+// an exact count.
+func RenderCount(count int) string {
+	if count == 0 {
+		return "Eligible participants: 0 (or fewer than 25 — exact counts under 25 aren't shown, to protect participant privacy)"
+	}
+
+	return fmt.Sprintf("Eligible participants: %d", count)
+}

--- a/cmd/eligibilitycount/count_test.go
+++ b/cmd/eligibilitycount/count_test.go
@@ -1,0 +1,310 @@
+package eligibilitycount_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prolific-oss/cli/client"
+	"github.com/prolific-oss/cli/cmd/eligibilitycount"
+	"github.com/prolific-oss/cli/mock_client"
+	"github.com/prolific-oss/cli/model"
+)
+
+func TestNewCountCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	cmd := eligibilitycount.NewCountCommand(c, os.Stdout)
+
+	use := "eligibility-count"
+	short := "Count participants matching a set of filters"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected short: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestCountCommandRendersCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	expectedPayload := client.EligibilityCountPayload{
+		Filters: []model.Filter{
+			{FilterID: "age", SelectedRange: &model.FilterRange{Lower: float64(18), Upper: float64(65)}},
+		},
+		WorkspaceID: "ws-id",
+	}
+
+	c.
+		EXPECT().
+		GetEligibilityCount(gomock.Eq(expectedPayload)).
+		Return(&client.EligibilityCountResponse{Count: 142}, nil).
+		Times(1)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	if _, err := f.WriteString(`{"filters": [{"filter_id": "age", "selected_range": {"lower": 18, "upper": 65}}]}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	writer.Flush()
+
+	expected := "Eligible participants: 142\n"
+	if b.String() != expected {
+		t.Fatalf("expected %q, got %q", expected, b.String())
+	}
+}
+
+func TestCountCommandFlagsSubTwentyFiveCounts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		GetEligibilityCount(gomock.Any()).
+		Return(&client.EligibilityCountResponse{Count: 0}, nil).
+		Times(1)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	if _, err := f.WriteString(`{"filters": []}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	writer.Flush()
+
+	if !strings.Contains(b.String(), "fewer than 25") {
+		t.Fatalf("expected sub-25 caveat in output, got %q", b.String())
+	}
+}
+
+func TestCountCommandSendsEmptyFiltersNotNil(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	expectedPayload := client.EligibilityCountPayload{
+		Filters:     []model.Filter{},
+		WorkspaceID: "ws-id",
+	}
+
+	c.
+		EXPECT().
+		GetEligibilityCount(gomock.Eq(expectedPayload)).
+		Return(&client.EligibilityCountResponse{Count: 30}, nil).
+		Times(1)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	// No "filters" key at all — must not leave Filters nil, since the API
+	// rejects a null filters field.
+	if _, err := f.WriteString(`{}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestCountCommandRequiresTemplatePath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	err := cmd.RunE(cmd, nil)
+
+	expected := "error: a filter template is required, use -t/--template-path"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}
+
+func TestCountCommandRequiresWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	if _, err := f.WriteString(`{"filters": []}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+	_ = cmd.Flags().Set("workspace", "")
+
+	err = cmd.RunE(cmd, nil)
+
+	expected := "error: workspace ID is required"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}
+
+func TestCountCommandHandlesFailureToReadConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", "broken-path.json")
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	err := cmd.RunE(cmd, nil)
+	writer.Flush()
+
+	expected := "error: open broken-path.json: no such file or directory"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}
+
+func TestCountCommandHandlesFailureToUnmarshalConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	// weightings must be a map; a scalar causes Unmarshal to fail
+	if _, err = f.WriteString("filters:\n  - filter_id: age\n    weightings: not-a-map\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	err = cmd.RunE(cmd, nil)
+	writer.Flush()
+
+	if err == nil || !strings.Contains(err.Error(), "unable to map") {
+		t.Fatalf("expected unmarshal error, got %v", err)
+	}
+}
+
+func TestCountCommandHandlesAPIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	c := mock_client.NewMockAPI(ctrl)
+
+	c.
+		EXPECT().
+		GetEligibilityCount(gomock.Any()).
+		Return(nil, errors.New("boom")).
+		Times(1)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	if _, err := f.WriteString(`{"filters": []}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	cmd := eligibilitycount.NewCountCommand(c, writer)
+	_ = cmd.Flags().Set("template-path", f.Name())
+	_ = cmd.Flags().Set("workspace", "ws-id")
+
+	err = cmd.RunE(cmd, nil)
+
+	expected := "error: boom"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prolific-oss/cli/cmd/campaign"
 	"github.com/prolific-oss/cli/cmd/collection"
 	"github.com/prolific-oss/cli/cmd/credentials"
+	"github.com/prolific-oss/cli/cmd/eligibilitycount"
 	"github.com/prolific-oss/cli/cmd/filters"
 	"github.com/prolific-oss/cli/cmd/filtersets"
 	"github.com/prolific-oss/cli/cmd/hook"
@@ -80,6 +81,7 @@ func NewRootCommand() *cobra.Command {
 		campaign.NewListCommand("campaign", &client, w),
 		collection.NewCollectionCommand(&client, w),
 		credentials.NewCredentialsCommand(&client, w),
+		eligibilitycount.NewCountCommand(&client, w),
 		filters.NewListCommand(&client, w),
 		filtersets.NewFilterSetCommand(&client, w),
 		hook.NewHookCommand(&client, w),

--- a/contract_test/contract_test.go
+++ b/contract_test/contract_test.go
@@ -117,7 +117,9 @@ var operations = []operation{
 	// Filters
 	{operationID: "get-filters", call: func(c *client.Client) { c.GetFilters() }},
 	{operationID: "get-filter-distribution", skip: "OUTOFSCOPE: filter distribution not needed in CLI"},
-	{operationID: "get-eligible-count", skip: "OUTOFSCOPE: eligibility count not needed in CLI"},
+	{operationID: "get-eligible-count", call: func(c *client.Client) {
+		c.GetEligibilityCount(client.EligibilityCountPayload{Filters: []model.Filter{}, WorkspaceID: "ws-id"})
+	}},
 
 	// Filter Sets
 	{operationID: "get-filter-sets", call: func(c *client.Client) { c.GetFilterSets("ws-id", 10, 0) }},

--- a/mock_client/mock_client.go
+++ b/mock_client/mock_client.go
@@ -660,6 +660,21 @@ func (mr *MockAPIMockRecorder) GetCollections(workspaceID, limit, offset interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCollections", reflect.TypeOf((*MockAPI)(nil).GetCollections), workspaceID, limit, offset)
 }
 
+// GetEligibilityCount mocks base method.
+func (m *MockAPI) GetEligibilityCount(payload client.EligibilityCountPayload) (*client.EligibilityCountResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEligibilityCount", payload)
+	ret0, _ := ret[0].(*client.EligibilityCountResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEligibilityCount indicates an expected call of GetEligibilityCount.
+func (mr *MockAPIMockRecorder) GetEligibilityCount(payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEligibilityCount", reflect.TypeOf((*MockAPI)(nil).GetEligibilityCount), payload)
+}
+
 // GetEvents mocks base method.
 func (m *MockAPI) GetEvents(subscriptionID string, limit, offset int) (*client.ListHookEventsResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

Adds `prolific eligibility-count`, a thin wrapper over `POST /api/v1/eligibility-count/` that counts participants matching a set of filters without creating a study (DCT-300).

```bash
$ prolific eligibility-count -t /path/to/filters.json -w <workspace-id>
Eligible participants: 142
```

Filters reuse the same JSON/YAML shape `study create` already accepts. Composite (and/or) filter groups are out of scope for v1.

The API floors counts below 25 to `0` for participant privacy (no enterprise override exists anywhere in the codebase — confirmed by reading the monolith source). Since `0` is ambiguous, the command says so explicitly:

```
Eligible participants: 0 (or fewer than 25 — exact counts under 25 aren't shown, to protect participant privacy)
```

## Implementation

- New client payload/response types + `GetEligibilityCount` method
- New flat top-level command `cmd/eligibilitycount` (same shape as `prolific filters`)
- `contract_test.go`: replaced the `get-eligible-count` `OUTOFSCOPE` skip with a real call — this caught a real bug: the live API rejects `"filters": null`, so a template omitting `filters` now defaults to `[]` before the request is sent
- `README.md` coverage table regenerated

## Testing

`cmd/eligibilitycount/count_test.go` covers rendering, the sub-25 caveat, the nil-filters fix, flag validation, and error paths. `make lint`, `make test` (incl. contract test against the live spec), `make build` all pass.