### PR TITLE
chore(release): v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,27 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 1.2.2
+
 ### Core
 
 - Tighten contract testing against the Prolific API spec
+
+### Core
+
+- Add eligibility-count command
+- Stop double-wrapping the UpdateStudy error
+- Truncate oversized API error details in CLI output
+- Extend ExecuteBuilder and migrate study/collection methods
+- Extract GetInto to dedupe the no-status GET chain
+- Migrate hook/workspace/project/participant-group methods
+- Use the Get convenience instead of the manual chain
+- Migrate filter-set/survey/collection/message/bonus methods
+- Migrate AI Task Builder batch methods to ExecuteBuilder
+- Migrate remaining AI Task Builder and credential pool methods
+- Use the Get convenience instead of the manual chain
+- Guard GetParticipantGroups request shape directly
+- Assert method and path in GetParticipantGroups test
 
 ## 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,10 @@
 ### Core
 
 - Tighten contract testing against the Prolific API spec
-
-### Core
-
 - Add eligibility-count command
-- Stop double-wrapping the UpdateStudy error
 - Truncate oversized API error details in CLI output
-- Extend ExecuteBuilder and migrate study/collection methods
-- Extract GetInto to dedupe the no-status GET chain
-- Migrate hook/workspace/project/participant-group methods
-- Use the Get convenience instead of the manual chain
-- Migrate filter-set/survey/collection/message/bonus methods
-- Migrate AI Task Builder batch methods to ExecuteBuilder
-- Migrate remaining AI Task Builder and credential pool methods
-- Use the Get convenience instead of the manual chain
+- Migrate all client methods to the ExecuteBuilder fluent interface
 - Guard GetParticipantGroups request shape directly
-- Assert method and path in GetParticipantGroups test
 
 ## 1.2.1
 


### PR DESCRIPTION
Automated release PR — detected unreleased user-facing commits since `v1.2.1`.

Version was auto-computed as a **PATCH** bump (`v1.2.1` -> `v1.2.2`). If this batch of changes includes a breaking change (a removed flag, a changed output format — see the version-bump table in DEVELOPMENT.md), edit the `## 1.2.2` heading in `CHANGELOG.md` to the next **MINOR** version before merging.

Merging this PR (with the `release` label, already applied) will trigger `create-release.yml` as usual — nothing is released until then.

Not the right time (other work still landing, want to batch more in)? Just close this without merging — it won't reopen itself, but if unreleased commits still remain, the next scheduled run will propose a fresh PR.
