### PR TITLE
fix(DCT-262): merge changelog sections that share a heading

### DIFF
--- a/scripts/changelog/main.go
+++ b/scripts/changelog/main.go
@@ -363,24 +363,102 @@ func ExtractSection(changelog, section string, stripComments bool) string {
 	return result
 }
 
-// MergeNotes combines manual and generated notes with a blank line separator.
-// If both are empty, the fallback text is returned.
+// changelogSection is a single "### Heading" block and its body lines, up to
+// (but not including) the next "### " heading. A section with an empty
+// heading holds content that appears before any heading.
+type changelogSection struct {
+	heading string
+	body    []string
+}
+
+// splitSections parses markdown into an ordered list of sections, splitting
+// on "### " headings.
+func splitSections(text string) []changelogSection {
+	var sections []changelogSection
+	var current *changelogSection
+
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "### ") {
+			sections = append(sections, changelogSection{heading: strings.TrimSpace(strings.TrimPrefix(line, "### "))})
+			current = &sections[len(sections)-1]
+			continue
+		}
+		if current == nil {
+			sections = append(sections, changelogSection{})
+			current = &sections[len(sections)-1]
+		}
+		current.body = append(current.body, line)
+	}
+
+	return sections
+}
+
+// render returns the section as markdown, or "" if it has no heading and no
+// non-blank body content.
+func (s changelogSection) render() string {
+	body := strings.TrimSpace(strings.Join(s.body, "\n"))
+	switch {
+	case s.heading == "":
+		return body
+	case body == "":
+		return "### " + s.heading
+	default:
+		return "### " + s.heading + "\n\n" + body
+	}
+}
+
+// MergeNotes combines manual and generated notes. Sections that share the
+// same "### Heading" in both inputs are merged into one occurrence of that
+// heading (manual bullets first, then generated), instead of appearing as
+// two separate same-named sections. If both are empty, the fallback text is
+// returned.
 func MergeNotes(manual, generated, fallback string) string {
 	manual = strings.TrimSpace(manual)
 	generated = strings.TrimSpace(generated)
 
-	var parts []string
-	if manual != "" {
-		parts = append(parts, manual)
-	}
-	if generated != "" {
-		parts = append(parts, generated)
-	}
-
-	if len(parts) == 0 {
+	if manual == "" && generated == "" {
 		return fallback + "\n"
 	}
-	return strings.Join(parts, "\n\n") + "\n"
+
+	generatedSections := splitSections(generated)
+	generatedIndexByHeading := make(map[string]int, len(generatedSections))
+	for i, s := range generatedSections {
+		if s.heading != "" {
+			generatedIndexByHeading[s.heading] = i
+		}
+	}
+	consumed := make([]bool, len(generatedSections))
+
+	var blocks []string
+	for _, s := range splitSections(manual) {
+		block := s.render()
+		if s.heading != "" {
+			if gi, ok := generatedIndexByHeading[s.heading]; ok && !consumed[gi] {
+				consumed[gi] = true
+				genBullets := strings.TrimSpace(strings.Join(generatedSections[gi].body, "\n"))
+				if genBullets != "" {
+					block = strings.TrimRight(block, "\n") + "\n" + genBullets
+				}
+			}
+		}
+		if block != "" {
+			blocks = append(blocks, block)
+		}
+	}
+
+	for i, s := range generatedSections {
+		if consumed[i] {
+			continue
+		}
+		if block := s.render(); block != "" {
+			blocks = append(blocks, block)
+		}
+	}
+
+	if len(blocks) == 0 {
+		return fallback + "\n"
+	}
+	return strings.Join(blocks, "\n\n") + "\n"
 }
 
 // reMarker matches the [hash:...][type:...] prefix emitted by cliff.toml.

--- a/scripts/changelog/main_test.go
+++ b/scripts/changelog/main_test.go
@@ -325,6 +325,27 @@ func TestMergeNotes(t *testing.T) {
 			fallback:  "fallback text",
 			want:      "fallback text\n",
 		},
+		{
+			name:      "manual and generated sharing a heading merge into one section",
+			manual:    "### Core\n\n- Tighten contract testing against the Prolific API spec",
+			generated: "### Core\n\n- Add eligibility-count command\n- Truncate oversized API error details in CLI output",
+			fallback:  "fallback",
+			want:      "### Core\n\n- Tighten contract testing against the Prolific API spec\n- Add eligibility-count command\n- Truncate oversized API error details in CLI output\n",
+		},
+		{
+			name:      "manual heading with no generated counterpart is kept separate",
+			manual:    "### Docs\n\n- Document homebrew installation",
+			generated: "### Core\n\n- Add eligibility-count command",
+			fallback:  "fallback",
+			want:      "### Docs\n\n- Document homebrew installation\n\n### Core\n\n- Add eligibility-count command\n",
+		},
+		{
+			name:      "generated headings with no manual counterpart pass through unchanged",
+			manual:    "",
+			generated: "### Core\n\n- Add eligibility-count command\n\n### Study\n\n- Some study change",
+			fallback:  "fallback",
+			want:      "### Core\n\n- Add eligibility-count command\n\n### Study\n\n- Some study change\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

PR #506's auto-generated v1.2.2 changelog had two separate `### Core` sections instead of one. Root cause: `MergeNotes` (`scripts/changelog/main.go`) concatenated the manual notes block (from `## next`) and the generated notes block (from git-cliff) as opaque text, with no awareness that both could independently contain a heading with the same name.

## Fix

`MergeNotes` now splits both inputs into sections by `### Heading`, and merges any heading that appears on both sides (manual bullets first, then generated) instead of emitting it twice. This isn't Core-specific — it matches on whatever heading text is shared, so it applies equally to `### Study`, `### Filters`, or any other area. Headings unique to one side pass through unchanged.

## Testing

Added 3 cases to `TestMergeNotes`: a shared heading (`### Core`) merges into one section; a manual-only heading (`### Docs`) stays separate from an unrelated generated-only heading (`### Core`), proving the match is per-heading, not hardcoded; and generated-only headings pass through unchanged (the common no-manual-notes case). All existing cases still pass. `make lint`, `make test`, `make build` all pass.