### PR TITLE
fix(DCT-261): correct three help-text drift issues from customer report

### DIFF
--- a/cmd/eligibilitycount/count.go
+++ b/cmd/eligibilitycount/count.go
@@ -63,7 +63,7 @@ $ prolific eligibility-count -t /path/to/filters.json -w <workspace-id>`,
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.TemplatePath, "template-path", "t", "", "Path to a YAML/JSON file containing the filters to count against")
+	flags.StringVarP(&opts.TemplatePath, "template-path", "t", "", "Path to a YAML/JSON file containing the filters to count against (required).")
 	flags.StringVarP(&opts.WorkspaceID, "workspace", "w", viper.GetString("workspace"), "The workspace ID to count eligible participants for (required).")
 
 	return cmd

--- a/cmd/filtersets/list.go
+++ b/cmd/filtersets/list.go
@@ -34,7 +34,7 @@ Filter Sets are assigned to a workspace.
 		Example: `
 List the Filter Sets you have defined in a given workspace
 
-$ prolific filters list -w 6261321e223a605c7a4f7623
+$ prolific filter-sets list -w 6261321e223a605c7a4f7623
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Args = args

--- a/cmd/message/list.go
+++ b/cmd/message/list.go
@@ -39,7 +39,7 @@ $ prolific message list -u 6262a15c0c745235a82a150c
 
 If, however, you want to see all messages in the last 30 days (or less), you can
 run
-$ prolific message list -c 2023-05-01
+$ prolific message list -c 2026-08-05
 
 You can also return unread messages. Please note, that if you call this command,
 it will not mark the messages as read in the web application.


### PR DESCRIPTION
## Summary
Fixes for a documentation bug report where hand-written help text — usage strings, examples, required-flag annotations — disagreed with actual CLI behavior. Addresses the three items that were genuine drift fixable in this repo:

- `filter-sets list --help` example ran `prolific filters list -w ...` — `filters` is an unrelated, subcommand-less command. Fixed to `prolific filter-sets list -w ...`.
- `eligibility-count -t/--template-path` flag description didn't note it was required, while `-w` does. Added "(required)" for consistency — `-t` has no config fallback, so it's always mandatory.
- `message list --help` example used a date far outside the flag's own documented "last 30 days" limit. Swapped to a recent literal date.

Two items from the report are out of scope for this PR:
- The `requirements` command doesn't exist because it was deliberately removed a while back in favor of `filters`/`eligibility-count`; the backing API endpoint is gone too. This needs a fix on the docs.prolific.com side, not here.
- `workspace balance [workspace-id]` being "wrongly optional" is disputed — the arg is genuinely optional given a configured default workspace (viper fallback), and the command's own Example text already documents that. Held for re-validation rather than changed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/filtersets/... ./cmd/message/... ./cmd/eligibilitycount/...`
- [x] Pre-commit hook ran full lint + test suite clean