### PR TITLE
chore(release): v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <!-- Add manual release notes here. They will be merged into the generated changelog at release time. -->
 
+## 1.2.4
+
+### Filters
+
+- Correct three help-text drift issues from customer report
+
 ## 1.2.3
 
 ### Feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 1.2.4
 
-### Filters
+### Core
 
 - Correct three help-text drift issues from customer report
 


### PR DESCRIPTION
Automated release PR — detected unreleased user-facing commits since `v1.2.3`.

Version was auto-computed as a **PATCH** bump (`v1.2.3` -> `v1.2.4`). If this batch of changes includes a breaking change (a removed flag, a changed output format — see the version-bump table in DEVELOPMENT.md), edit the `## 1.2.4` heading in `CHANGELOG.md` to the next **MINOR** version before merging.

Merging this PR (with the `release` label, already applied) will trigger `create-release.yml` as usual — nothing is released until then.

Not the right time (other work still landing, want to batch more in)? Just close this without merging — it won't reopen itself, but if unreleased commits still remain, the next scheduled run will propose a fresh PR.
