### PR TITLE
chore(CLO2-0): Use standard dockerhub push token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: prolificautomation
+          password: ${{ secrets.DOCKERHUB_WRITE_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
Previous token was a regular user token, replace with the standard prolific automation service account token used across other repos. 